### PR TITLE
Fix typo: [K:F] ≥ |Aut(K/F)|

### DIFF
--- a/tex/alg-NT/galois.tex
+++ b/tex/alg-NT/galois.tex
@@ -652,7 +652,7 @@ First, we extract a useful fragment from the fundamental theorem.
 
 The inequality itself is not difficult:
 \begin{exercise}
-	Show that $[K:F] \ge \Aut(K/F)$,
+	Show that $[K:F] \ge |\Aut(K/F)|$,
 	and that equality holds if and only if
 	the set of elements fixed by all $\sigma \in \Aut(K/F)$
 	is exactly $F$.


### PR DESCRIPTION
From

> [K:F] ≥ Aut(K/F)

to

> [K:F] ≥ |Aut(K/F)|

since Aut(K/F) is a set, not an integer.