### PR TITLE
fix typos in cardinal.tex

### DIFF
--- a/tex/set-theory/cardinal.tex
+++ b/tex/set-theory/cardinal.tex
@@ -275,7 +275,7 @@ In fact, this holds even more generally:
 	To do so, it suffices to prove that for any $\ol\gamma \in \gamma$,
 	we have $\left\lvert \ol\gamma \right\rvert < \kappa$.
 
-	Suppose $\ol\gamma$ corresponds to the point $(\alpha, \beta) \in \kappa$
+	Suppose $\ol\gamma$ corresponds to the point $(\alpha, \beta) \in \kappa \times \kappa$
 	under this bijection.
 	If $\alpha$ and $\beta$ are both finite
 	then certainly $\ol\gamma$ is finite too.

--- a/tex/set-theory/cardinal.tex
+++ b/tex/set-theory/cardinal.tex
@@ -185,7 +185,7 @@ The definition of cardinal arithmetic is as expected:
 	\]
 	and
 	\[
-		k \cdot \mu
+		\kappa \cdot \mu
 		\defeq
 		\left\lvert \mu \times \kappa \right\rvert
 		.
@@ -246,7 +246,7 @@ In fact, this holds even more generally:
 	rather than $\alpha+\beta$.
 	Specifically, we put the ordering $<_{\text{max}}$
 	on $\kappa \times \kappa$ as follows:
-	for $(\alpha_1, \beta_1)$ and $(\alpha_1, \beta_2)$ in $\kappa \times \kappa$
+	for $(\alpha_1, \beta_1)$ and $(\alpha_2, \beta_2)$ in $\kappa \times \kappa$
 	we declare $(\alpha_1, \beta_1) <_{\text{max}} (\alpha_2, \beta_2)$ if
 	\begin{itemize}
 		\ii $\max \left\{ \alpha_1, \beta_1 \right\} < \max \left\{ \alpha_2, \beta_2 \right\}$ or


### PR DESCRIPTION
in section 83.4 cardinal arithmetic
replaced "k" with "\kappa" and "(\alpha_1, \beta_2)" with "(\alpha_2, \beta_2)"