### PR TITLE
Measure example typo

### DIFF
--- a/tex/measure/measure-space.tex
+++ b/tex/measure/measure-space.tex
@@ -284,7 +284,7 @@ This is the reason why we considered $\sigma$-algebras in the first place.
 		This is called the \vocab{counting measure},
 		simply counting the number of elements.
 
-		This is useful if $\Omega$ is countably finite,
+		This is useful if $\Omega$ is countably infinite,
 		and optimal if $\Omega$ is finite (and nonempty).
 		In the latter case, we will often normalize by
 		$\mu(A) = \frac{|A|}{|\Omega|}$


### PR DESCRIPTION
I guess that should be "countably infinite" instead of "countably finite" or am I missing something?
