### PR TITLE
Fix typos in H113 and topology

### DIFF
--- a/tex/H113/rings.tex
+++ b/tex/H113/rings.tex
@@ -326,7 +326,7 @@ so $6 = (-2)(-3) = 2 \cdot 3$ are considered the same.
 The general definition goes as follows.
 \begin{definition}
 	A nonzero non-unit of an integral domain $R$ is
-	\vocab{irreducible} if cannot be written as the product of two non-units.
+	\vocab{irreducible} if it cannot be written as the product of two non-units.
 
 	An integral domain $R$ is a \vocab{unique factorization domain}
 	if every nonzero non-unit of $R$ can be written

--- a/tex/H113/structure.tex
+++ b/tex/H113/structure.tex
@@ -1,7 +1,7 @@
 \chapter{The PID structure theorem}
 The main point of this chapter is to discuss a classification
 theorem for finitely generated abelian groups.
-This won't take long to do, and if you like you can read
+This won't take long to do, and if you like, you can read
 just the first section and then move on.
 
 However, since I'm here, I will go ahead and state the result as a

--- a/tex/topology/compactness.tex
+++ b/tex/topology/compactness.tex
@@ -128,7 +128,7 @@ We also have:
 Now we can prove the main theorem about Euclidean space:
 in $\RR^n$, compactness is equivalent to being ``closed and bounded''.
 \begin{theorem}[Bolzano-Weierstra\ss]
-	A subset of $\RR^n$ is compact if and only if it closed and bounded.
+	A subset of $\RR^n$ is compact if and only if it is closed and bounded.
 	\label{thm:fakeBW}
 \end{theorem}
 \begin{ques}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38930062/65937472-d81f1b80-e3d4-11e9-9fae-ac3ca613c6e3.png)

Also the above seems like a formatting issue, but I don't know enough about LaTex to fix it.