### PR TITLE
Fix typo regarding Stokes' theorem

### DIFF
--- a/tex/diffgeo/manifolds.tex
+++ b/tex/diffgeo/manifolds.tex
@@ -399,8 +399,8 @@ but I won't define this because the definition is truly awful.
 Then Stokes' theorem says
 \begin{theorem}
 	[Stokes' theorem for manifolds]
-	Let $M$ be an smooth oriented $n$-manifold with boundary
-	and let $\alpha$ be a compactly supported $n$-form.
+	Let $M$ be a smooth oriented $n$-manifold with boundary
+	and let $\alpha$ be a compactly supported $n-1$-form.
 	Then
 	\[ \int_M d\alpha = \int_{\partial M} \alpha. \]
 \end{theorem}

--- a/tex/diffgeo/stokes.tex
+++ b/tex/diffgeo/stokes.tex
@@ -425,7 +425,7 @@ We now have all the ingredients to state Stokes' theorem for cells.
 \begin{theorem}
 	[Stokes' theorem for cells]
 	Take $U \subseteq V$ as usual, let $c : [0,1]^k \to U$ be a $k$-cell
-	and let $\alpha : U \to \Lambda^k(V^\vee)$ be a $k$-form.
+	and let $\alpha : U \to \Lambda^{k-1}(V^\vee)$ be a $k-1$-form.
 	Then
 	\[ \int_c d\alpha = \int_{\partial c} \alpha. \]
 	In particular, if $d\alpha = 0$ then the left-hand side vanishes.


### PR DESCRIPTION
If M is a smooth oriented n-manifold with boundary, α should be n-1 form.

###### Reference
- https://en.wikipedia.org/w/index.php?title=Stokes%27_theorem&oldid=915663472#Formulation_for_smooth_manifolds_with_boundary