### PR TITLE
stokes.tex: Remove a chili pepper from the problem 44E

### DIFF
--- a/tex/diffgeo/stokes.tex
+++ b/tex/diffgeo/stokes.tex
@@ -472,7 +472,6 @@ and thus we obtain the fundamental theorem of calculus.
 \end{problem}
 
 \begin{problem}
-	\gim
 	An \vocab{exact} $k$-form $\alpha$ is one satisfying $\alpha = d\beta$ for some $\beta$.
 	Prove that
 	\[ \int_{C_1} \alpha = \int_{C_2} \alpha \]


### PR DESCRIPTION
The hint of problem 44E seems to be using the complex property of annulus, but I think I have found an easy solution. Please let me know if there's any error.

With Stokes' theorem:

<p align=center><img width="500" alt="
    \int_{\partial C_1} \beta = \int_0 \beta = 0
    \int_{\partial C_2} \beta = \int_0 \beta = 0
" src="https://user-images.githubusercontent.com/4435445/66128154-35f77180-e628-11e9-85c0-2c83acfd1e23.png"></p>

Since C_1 and C_2 is concentric circles:

<p align=center><img width="200" alt="
    \partial C_1 = \partial C_2 = 0
" src="https://user-images.githubusercontent.com/4435445/66128204-59222100-e628-11e9-9adb-4f463b821496.png"></p>

So the following formula holds:

<p align=center><img width="400" alt="
    \int_{\partial C_1} \beta = \int_0 \beta = 0
    \int_{\partial C_2} \beta = \int_0 \beta = 0
" src="https://user-images.githubusercontent.com/4435445/66128247-6e974b00-e628-11e9-991a-aac38bf2fa64.png"></p>

Finally,

<p align=center><img width="200" alt="
    \int_{C_1} \alpha = \int_{C_2} \alpha = 0
" src="https://user-images.githubusercontent.com/4435445/66128302-8a9aec80-e628-11e9-8baf-288788d635fb.png"></p>