### PR TITLE
Remove redundant sentences in Group actions section

### DIFF
--- a/tex/H113/action.tex
+++ b/tex/H113/action.tex
@@ -26,10 +26,8 @@ We can make all of this precise using the idea of a group action.
 	\end{itemize}
 \end{definition}
 
-Here are some more examples of group actions.
 \begin{example}[Examples of group actions]
 	Let $G=(G,\star)$ be a group.
-	Here are some examples of group actions.
 	\begin{enumerate}[(a)]
 		\ii The group $\Zc 4$ can act on the set of ways to color a $7 \times 7$
 		board either yellow or green.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38930062/67542118-4c7d6f80-f6a0-11e9-88b9-d6ea3d97032c.png)

These two sentences seem redundant, especially with the "Example of group actions" header.