### PR TITLE
Disambiguate 'element' to 'eigenvalue'

### DIFF
--- a/tex/linalg/eigenvalues.tex
+++ b/tex/linalg/eigenvalues.tex
@@ -10,7 +10,7 @@ What's the simplest type of linear map?
 It would just be multiplication by some scalar $\lambda$,
 which would have associated matrix (in any basis!)
 \[
-	T = 
+	T =
 	\begin{bmatrix}
 		\lambda & 0 & \dots & 0 \\
 		0 & \lambda & \dots & 0 \\
@@ -239,7 +239,7 @@ I'll explain later how to interpret the $1$'s,
 when I make up the word \emph{descending staircase}.
 For now, you should note that even if $\dim J_i \ge 2$,
 we still have a basis element
-which is an eigenvector with element $\lambda_i$.
+which is an eigenvector with eigenvalue $\lambda_i$.
 
 \begin{example}
 	[A concrete example of Jordan form]
@@ -316,7 +316,7 @@ As another example, we can have multiple such staircases.
 \begin{example}
 	[Double staircase]
 	Let $V = k^{\oplus 5}$ have basis $e_1$, $e_2$, $e_3$, $e_4$, $e_5$.
-	Then the map 
+	Then the map
 	\[ e_3 \mapsto e_2 \mapsto e_1 \mapsto 0 \text{ and }
 		e_5 \mapsto e_4 \mapsto 0 \]
 	is nilpotent.
@@ -395,7 +395,7 @@ Now I'm going to be cheap, and define:
 	where both $W_1$ and $W_2$ are nontrivial $T$-invariant spaces.
 \end{definition}
 Picture of a \emph{decomposable} map:
-\[ 
+\[
 	\begin{bmatrix}
 		\multicolumn{2}{c|}{\multirow{2}{*}{$W_1$}} & 0 & 0 & 0  \\
 		\multicolumn{2}{c|}{} & 0 & 0 & 0 \\ \hline


### PR DESCRIPTION
My text editor automatically gets rid of trailing whitespace.