### PR TITLE
Fix typo in linear independence of vectors

### DIFF
--- a/tex/linalg/eigenvalues.tex
+++ b/tex/linalg/eigenvalues.tex
@@ -152,7 +152,7 @@ algebraically closed field\footnote{A field is \vocab{algebraically closed}
 	Let $n = \dim V < \infty$ and fix any nonzero vector $v \in V$,
 	and consider vectors $v$, $T(v)$, \dots, $T^n (v)$.
 	There are $n+1$ of them,
-	so they must not be linearly dependent for dimension reasons;
+	so they can't be linearly independent for dimension reasons;
 	thus there is a nonzero polynomial $P$ such that $P(T)$
 	is zero when applied to $v$.
 	WLOG suppose $P$ is a monic polynomial,

--- a/tex/linalg/eigenvalues.tex
+++ b/tex/linalg/eigenvalues.tex
@@ -152,7 +152,7 @@ algebraically closed field\footnote{A field is \vocab{algebraically closed}
 	Let $n = \dim V < \infty$ and fix any nonzero vector $v \in V$,
 	and consider vectors $v$, $T(v)$, \dots, $T^n (v)$.
 	There are $n+1$ of them,
-	so they must be linearly dependent for dimension reasons;
+	so they must not be linearly dependent for dimension reasons;
 	thus there is a nonzero polynomial $P$ such that $P(T)$
 	is zero when applied to $v$.
 	WLOG suppose $P$ is a monic polynomial,


### PR DESCRIPTION
I have found a typo for the following.

> Let n = dim V. There are n+1 vectors, so they must **not** be linearly independent for dimension reasons.