### PR TITLE
Fix typo in inner-form.tex

### DIFF
--- a/tex/linalg/inner-form.tex
+++ b/tex/linalg/inner-form.tex
@@ -386,7 +386,7 @@ Then consider the sequence
 	so you could skip this proof if you haven't read the chapter.
 	The sequence $v_i$ converges if and only if it is Cauchy,
 	meaning that when $i < j$,
-	\[ \norm{v_j - v_i}^2 = |c_i|^2 + \dots + |c_{j-1}|^2 \]
+	\[ \norm{v_j - v_i}^2 = |c_{i+1}|^2 + \dots + |c_j|^2 \]
 	tends to zero as $i$ and $j$ get large.
 	This is equivalent to the sequence
 	$s_n = |c_1|^2 + \dots + |c_n|^2$ being Cauchy.

--- a/tex/linalg/inner-form.tex
+++ b/tex/linalg/inner-form.tex
@@ -400,7 +400,7 @@ Then consider the sequence
 
 Thus, when we have a Hilbert space, we change our definition slightly:
 \begin{definition}
-	A \vocab{orthonormal basis} for a Hilbert space $V$
+	An \vocab{orthonormal basis} for a Hilbert space $V$
 	is a (possibly infinite) sequence $e_1$, $e_2$, \dots,
 	of vectors such that
 	\begin{itemize}


### PR DESCRIPTION
It seems that

```
v_j - v_i = c_{i+1} e_{i+1} + ... + c_j e_j
```

so the square of its norm is

```
||v_j - v_i||^2 = |c_{i+1}|^2 + ... + |c_j|^2.
```