### PR TITLE
Fix typo in fourier.tex

### DIFF
--- a/tex/linalg/fourier.tex
+++ b/tex/linalg/fourier.tex
@@ -383,7 +383,7 @@ the coefficient of $e_\xi$ in $f$ is $\left< f, e_\xi\right>$.
 	Let $f : Z \to \CC$, where $Z$ is a finite abelian group.
 	Then \[ \left< f,g \right> = \sum_{\xi \in Z} \wh f(\xi) \ol{\wh g(\xi)}. \]
 	Similarly, if $f : [-\pi, \pi] \to \CC$ is square-integrable then
-	\[ \left< f,g \right> = \sum_n \wh f(\xi) \ol{\wh g(\xi)}. \]
+	\[ \left< f,g \right> = \sum_n \wh f(n) \ol{\wh g(n)}. \]
 \end{corollary}
 \begin{ques}
 	Prove this one in one line (like before).


### PR DESCRIPTION
It seems that regarding functions in `L^2([-\pi, \pi])`, the frequency set is indexed by integers, so the inner form should look like

```
\sum_n \wh f(n) \ol{\wh g(n) }.
```