### PR TITLE
Fix small typo in transpose.tex

### DIFF
--- a/tex/linalg/transpose.tex
+++ b/tex/linalg/transpose.tex
@@ -183,7 +183,7 @@ for inner product spaces: since it can be defined using only the inner product
 with making mention to dual spaces at all.
 \begin{definition}
 	Let $V$ and $W$ be finite-dimensional inner product spaces,
-	and let $T \colon W \to V$.
+	and let $T \colon V \to W$.
 	The \vocab{adjoint} or \vocab{conjugate transpose}
 	of $T$, denoted $T^\dagger \colon W \to V$,
 	is defined as follows: for every vector $w \in W$,


### PR DESCRIPTION
It seems that according to the content afterwards `T` is a linear map from `V` to `W`.