### PR TITLE
Fix typo in monic maps of categories.tsx

### DIFF
--- a/tex/cats/categories.tex
+++ b/tex/cats/categories.tex
@@ -529,7 +529,7 @@ The correct categorical notion is:
 In most but not all situations, the converse is also true.
 \begin{exercise}
 	Show that in $\catname{Set}$, $\catname{Grp}$, $\catname{CRing}$,
-	monic implies injective. (Take $A = \{\ast\}$, $A = \{1\}$, $A = \ZZ[x]$.)
+	monic implies injective. (Take $A = \{\ast\}$, $A = \ZZ$, $A = \ZZ[x]$.)
 \end{exercise}
 More generally, as we said before there are many categories
 with a ``free'' object that you can use to think of as elements.


### PR DESCRIPTION
When proving “monic maps are injective in the category of groups”, it seems that the original intention was to take maps from integers `Z`, since maps from `Z` to any group represents the elements of that group.