### PR TITLE
Fix typo of infinite series in p-adic numbers

### DIFF
--- a/tex/calculus/p-adic.tex
+++ b/tex/calculus/p-adic.tex
@@ -402,7 +402,7 @@ With this definition in place,
 the ``base $p$'' discussion we had earlier is now true
 in the analytic sense: if $x = \ol{\dots a_2 a_1 a_0}_p \in \ZZ_p$ then
 \[ \sum_{k=0}^\infty a_k p^k \quad\text{converges to } x. \]
-Indeed, the $n$th partial sum is divisible by $p^n$,
+Indeed, the difference between $x$ and the $n$th partial sum is divisible by $p^n$,
 hence the partial sums approach $x$ as $n \to \infty$.
 
 While the definitions are all the same,


### PR DESCRIPTION
It seems that it is the difference between `x` and the `n`th partial sum which is divisible by `p^n`.