### PR TITLE
Fix typo in forcing.tex

### DIFF
--- a/tex/set-theory/forcing.tex
+++ b/tex/set-theory/forcing.tex
@@ -356,7 +356,7 @@ V_2 = \left\{ \varnothing, \left\{ \varnothing \right\} \right\}. \]
 		\end{cases}
 	\]
 	In particular, remembering that $G$ is nonempty we see that
-	\[ \left\{ \tau^G \mid \tau \in \Name_2 \right\} = V_2^M. \]
+	\[ \left\{ \tau^G \mid \tau \in \Name_2 \right\} = V_2. \]
 	In fact, this holds for any natural number $n$, not just $2$.
 \end{example}
 So, $M[G]$ and $M$ agree on finite sets.


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4435445/78257722-34562a00-7535-11ea-9188-3faea47494db.png)

As far as I know the book have never defined what `V_2^M` is. I thought that it's a typo, but please enlighten me if that was not a typo :)