### PR TITLE
forcing.tex: Fix typo

### DIFF
--- a/tex/set-theory/forcing.tex
+++ b/tex/set-theory/forcing.tex
@@ -379,9 +379,9 @@ Basically, $\check x$ is just a copy of $x$ where we add check marks and tag eve
 
 However, we'd also like to cause $G$ to be in $M[G]$.
 In fact, we can write down the name exactly:
-\[ \dot G = \left\{ \left<\check p, p\right> \mid p \in \Po \right\}. \]
+\[ \dot \Po = \left\{ \left<\check p, p\right> \mid p \in \Po \right\}. \]
 \begin{ques}
-	Show that $(\dot G)^G = G$.
+	Show that $(\dot \Po)^G = G$.
 \end{ques}
 \begin{ques}
 	Verify that $M[G]$ is transitive:

--- a/tex/set-theory/forcing.tex
+++ b/tex/set-theory/forcing.tex
@@ -378,8 +378,8 @@ Basically, $\check x$ is just a copy of $x$ where we add check marks and tag eve
 \end{ques}
 
 However, we'd also like to cause $G$ to be in $M[G]$.
-In fact, we can write down the name exactly:
-\[ \dot \Po = \left\{ \left<\check p, p\right> \mid p \in \Po \right\}. \]
+In fact, we can write down the name exactly: we define
+\[ \dot \Po \defeq \left\{ \left<\check p, p\right> \mid p \in \Po \right\}. \]
 \begin{ques}
 	Show that $(\dot \Po)^G = G$.
 \end{ques}


### PR DESCRIPTION
It changes "dot G" into "dot poset", since "dot G" has nothing to do with G.

![a](https://user-images.githubusercontent.com/4435445/79047018-2dbf6500-7c4f-11ea-8e41-bad53e466915.png)
