### PR TITLE
forcing.tex: Fix typo

### DIFF
--- a/tex/set-theory/forcing.tex
+++ b/tex/set-theory/forcing.tex
@@ -576,8 +576,8 @@ From this we get:
 	By the contrapositive of the previous lemma,
 	$\{q \mid q \Vdash \varphi\}$ is not dense below $p$,
 	meaning for some $\ol p \le p$, every $q \le \ol p$ gives $q \not\Vdash \varphi$.
-	By the definition of $p \vDash \neg\varphi$,
-	we have $\ol p \vDash \neg\varphi$.
+	By the definition of $p \Vdash \neg\varphi$,
+	we have $\ol p \Vdash \neg\varphi$.
 \end{proof}
 And this gives the converse: the $M$-generic $G$ has to hit some condition
 that passes judgment, one way or the other.


### PR DESCRIPTION
Forcing relation symbol should be used at that location.

![a](https://user-images.githubusercontent.com/4435445/79771763-30fed300-836a-11ea-8392-c002fe218824.png)