### PR TITLE
Define the notation \ker

### DIFF
--- a/tex/linalg/vector-space.tex
+++ b/tex/linalg/vector-space.tex
@@ -636,8 +636,8 @@ doesn't depend on the choice of a basis.
 \end{definition}
 
 \begin{example}[Kernels]
-	The \vocab{kernel} of a map $T \colon V \to W$ is the
-	set of $v \in V$ such that $T(v) = 0_W$.
+	The \vocab{kernel} of a map $T \colon V \to W$ (written $\ker T$) is
+	the set of $v \in V$ such that $T(v) = 0_W$.
 	It is a subspace of $V$, since it's closed under addition and scaling (why?).
 \end{example}
 \begin{example}[Spans]


### PR DESCRIPTION
I don't see where in between where we define "kernel" and first use \ker (just a bit below) we define the (pretty obvious, but still) notation \ker.