### PR TITLE
Clarify use of "id" as identity matrix.

### DIFF
--- a/tex/backmatter/notation.tex
+++ b/tex/backmatter/notation.tex
@@ -80,6 +80,7 @@ Notation with rings:
 \end{itemize}
 Linear algebra:
 \begin{itemize}
+	\ii $\id$: the identity matrix
 	\ii $V \oplus W$: direct sum
 	\ii $V^{\oplus n}$: direct sum of $V$, $n$ times
 	\ii $V \otimes W$: tensor product

--- a/tex/linalg/eigenvalues.tex
+++ b/tex/linalg/eigenvalues.tex
@@ -160,8 +160,8 @@ algebraically closed field\footnote{A field is \vocab{algebraically closed}
 	Then we get
 	\[ 0 = (T - r_1 \id) \circ (T - r_2 \id) \circ \dots
 		\circ (T - r_m \id)(v) \]
-	which means at least one of $T - r_i \id$ is not injective,
-	i.e.\ has a nontrivial kernel,
+	(where $\id$ is the identity matrix).  This means at least one of
+	$T - r_i \id$ is not injective, i.e.\ has a nontrivial kernel,
 	which is the same as an eigenvector.
 \end{proof}
 So in general we like to consider algebraically closed fields.


### PR DESCRIPTION
This wasn't obvious to me; I'm used to seeing "I" as the identity
matrix.  Clarify it the first time it's used in the linear algebra
section, and add an entry in the glossary.