### PR TITLE
Be consistent about k^{\oplus n}.

### DIFF
--- a/tex/linalg/eigenvalues.tex
+++ b/tex/linalg/eigenvalues.tex
@@ -294,7 +294,7 @@ Bear with me for a moment.  First, define:
 What's an example of a nilpotent map?
 \begin{example}
 	[The ``descending staircase'']
-	Let $V = k^3$ have basis $e_1$, $e_2$, $e_3$.
+        Let $V = k^{\oplus 3}$ have basis $e_1$, $e_2$, $e_3$.
 	Then the map $T$ which sends
 	\[ e_3 \mapsto e_2 \mapsto e_1 \mapsto 0 \]
 	is nilpotent, since $T(e_1) = T^2(e_2) = T^3(e_3) = 0$,


### PR DESCRIPTION
The example directly below uses \oplus n, so might as well use it here.