### PR TITLE
Rename Bertrand's Paradox to Russell's Paradox in zfc.tex

### DIFF
--- a/tex/set-theory/zfc.tex
+++ b/tex/set-theory/zfc.tex
@@ -50,7 +50,7 @@ We would have the oddity that $V \in V$,
 but oh well, no big deal.
 
 Unfortunately, this existence of this $V$ leads immediately to a paradox.
-The classical one is Bertrand's Paradox.
+The classical one is Russell's Paradox.
 I will instead present a somewhat simpler one:
 not only does $V$ contain itself, \emph{every subset $S \subseteq V$}
 is itself an element of $V$ (i.e. $S \in V$).


### PR DESCRIPTION
I believe you are referring to Bertrand Russell, this change is to avoid ambiguity with Bertrand's paradox in probability (which was new to me): https://en.wikipedia.org/wiki/Bertrand_paradox_(probability).