### PR TITLE
Rename "vector fields" to "vector spaces" in vector-space.tex

### DIFF
--- a/tex/linalg/vector-space.tex
+++ b/tex/linalg/vector-space.tex
@@ -891,7 +891,7 @@ I would pick 55a in a heartbeat.
 
 \section{A word on general modules}
 \prototype{$\ZZ[\sqrt2]$ is a $\ZZ$-module of rank two.}
-I focused mostly on vector fields (aka modules over a field) in this chapter
+I focused mostly on vector spaces (aka modules over a field) in this chapter
 for simplicity, so I want to make a few remarks about
 modules over a general commutative ring $R$ before concluding.
 


### PR DESCRIPTION
I believe this is a typo.