### PR TITLE
Make the example of homeomorphism between (-1; 1) and R less confusing

### DIFF
--- a/tex/topology/metric-top.tex
+++ b/tex/topology/metric-top.tex
@@ -347,7 +347,7 @@ Here are some examples.
 	Surprisingly, the open interval $(-1,1)$
 	is homeomorphic to the real line $\RR$!
 	One bijection is given by
-	\[ x \mapsto \tan(\pi/2 x) \]
+	\[ x \mapsto \tan(x \pi/2) \]
 	with the inverse being given by $t \mapsto \frac2\pi \arctan(t)$.
 
 	This might come as a surprise,


### PR DESCRIPTION
Currently, it renders as tan(pi/2x), which suggests that the x is in the denominator.