### PR TITLE
Improve formatting of remark in linear algebra

### DIFF
--- a/tex/linalg/vector-space.tex
+++ b/tex/linalg/vector-space.tex
@@ -397,8 +397,9 @@ that bases in vector spaces behave as nicely as possible.
 	must always not be zero.
 	Since we can eventually get to $A_m$, we have $n \ge m$.
 \end{proof}
-\begin{remark}
+\begin{remark*}
 	[Generalizations]
+	\hfill
 	\begin{itemize}
 		\ii The theorem is true for an infinite basis as well
 		if we interpret ``the number of elements'' as ``cardinality''.
@@ -407,7 +408,7 @@ that bases in vector spaces behave as nicely as possible.
 		Interestingly, the proof for the general case proceeds by reducing
 		to the case of a vector space.
 	\end{itemize}
-\end{remark}
+\end{remark*}
 
 The dimension theorem, true to its name,
 lets us define the \vocab{dimension} of

--- a/tex/preamble.tex
+++ b/tex/preamble.tex
@@ -285,6 +285,14 @@ style=thmbluebox,name=Theorem,numberwithin=section]{theorem}
 	mdframed={style=mdgreenbox},
 	headpunct={ --- },
 ]{thmgreenbox}
+\declaretheoremstyle[
+	headfont=\bfseries\sffamily\color{ForestGreen!70!black},
+	bodyfont=\normalfont,
+	spaceabove=2pt,
+	spacebelow=1pt,
+	mdframed={style=mdgreenbox},
+	headpunct={},
+]{thmgreenbox*}
 
 \mdfdefinestyle{mdblackbox}{%
 	skipabove=8pt,
@@ -308,6 +316,7 @@ style=thmbluebox,name=Theorem,numberwithin=section]{theorem}
 \declaretheorem[name=Question,sibling=theorem,style=thmblackbox]{ques}
 \declaretheorem[name=Exercise,sibling=theorem,style=thmblackbox]{exercise}
 \declaretheorem[name=Remark,sibling=theorem,style=thmgreenbox]{remark}
+\declaretheorem[name=Remark,sibling=theorem,style=thmgreenbox*]{remark*}
 \declaretheorem[name=Step,style=thmgreenbox]{step} % only used in Lebesgue int
 
 \theoremstyle{definition}


### PR DESCRIPTION
As a follow-up to #100, this PR fixes up the formatting like this:

![napkin-remark](https://user-images.githubusercontent.com/23580910/96124087-adc2d200-0ef3-11eb-9755-ad53765324da.png)

... by introducing a `remark*` environment, which omits the hyphen, and using it for
the remark.