### PR TITLE
Fix typo in mor-scheme.tex

### DIFF
--- a/tex/alg-geom/mor-scheme.tex
+++ b/tex/alg-geom/mor-scheme.tex
@@ -668,7 +668,7 @@ We can finally state the isomorphism that we wanted for a long time
 
 We now reprise \Cref{subsec:punctured_plane}
 (except $\CC$ will be replaced by $k$).
-We have seen it is an open subset $U$ of $\Spec k[x,y]$, so it is affine.
+We have seen it is an open subset $U$ of $\Spec k[x,y]$, so it is a scheme.
 \begin{ques}
 	Show that in fact $U$ can be covered by
 	two open sets which are both affine.


### PR DESCRIPTION
Punctured plane is an open subset of Spec k[x,y], but it is not an affine scheme, so I think this is a typo.