### PR TITLE
typo: prime ideals of R/I are prime ideals of R containing I

### DIFF
--- a/tex/alg-geom/spec-examples.tex
+++ b/tex/alg-geom/spec-examples.tex
@@ -252,8 +252,7 @@ so this should be a scheme with two points.
 
 To see this come true, we use \Cref{prop:prime_quotient}:
 the points of $\Spec k[x]/(x^2-x)$
-should correspond to prime ideals of $k[x]$
-contained in $(x^2-x)$.
+should correspond to prime ideals of $k[x]$ containing $(x^2-x)$.
 As $k[x]$ is a PID, there are only two, $(x-1)$ and $(x)$.
 They are each maximal,
 since their quotient with $k[x]$ is a field (namely $k$),


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/8658852/112626430-31df9500-8e56-11eb-956f-7b2e4f2d653f.png)

The highlighted part was changed to 'containing'.