### PR TITLE
fix typos in transpose.tex

### DIFF
--- a/tex/linalg/transpose.tex
+++ b/tex/linalg/transpose.tex
@@ -81,9 +81,9 @@ Of course, this should work in general.
 \end{theorem}
 \begin{proof}
 	The $(i,j)$th entry of the matrix $T$
-	corresponds to the coefficient of $f_j$ in $T(e_i)$,
-	which corresponds to the coefficient of $e_i^\vee$
-	in $f_j^\vee \circ T$.
+	corresponds to the coefficient of $f_i$ in $T(e_j)$,
+	which corresponds to the coefficient of $e_j^\vee$
+	in $f_i^\vee \circ T$.
 \end{proof}
 The nice part of this is that the definition of $T^\vee$ is basis-free.
 So it means that if we start with any linear map $T$,


### PR DESCRIPTION
If I'm not mistaken the indices in the proof of Theorem 15.1.3 should be swapped