### PR TITLE
Ideals typos.

### DIFF
--- a/tex/H113/grp-intro.tex
+++ b/tex/H113/grp-intro.tex
@@ -319,8 +319,8 @@ Now we state a slightly more useful proposition.
 	Direct computation. We have
 	\[ (ab)(b\inv a\inv)
 		= a (bb\inv) a\inv = aa\inv = 1_G. \]
-	Hence $(ab)\inv = b\inv a\inv$.
 	Similarly, $(b\inv a\inv)(ab) = 1_G$ as well.
+	Hence $(ab)\inv = b\inv a\inv$.
 \end{proof}
 
 Finally, we state a very important lemma about groups,

--- a/tex/H113/ideals.tex
+++ b/tex/H113/ideals.tex
@@ -404,7 +404,7 @@ More explicitly,
 	Obviously the conditions are necessary.
 	To see they're sufficient, we \emph{define} a ring by ``cosets''
 	\[ S = \left\{ r + I \mid r \in R \right\}. \]
-	These are the equivalence where we say $r_1 \sim r_2$ if $r_1 - r_2 \in I$
+	These are the equivalence classes under $r_1 \sim r_2$ if and only if $r_1 - r_2 \in I$
 	(think of this as taking ``mod $I$'').
 	To see that these form a ring, we have to check that the addition
 	and multiplication we put on them is well-defined.

--- a/tex/H113/ideals.tex
+++ b/tex/H113/ideals.tex
@@ -314,7 +314,7 @@ consider the map $\ZZ \to \ZZ$ called ``multiply by zero''.
 	might have thought were homomorphisms will fail.
 	\begin{enumerate}[(a)]
 		\ii The map $\ZZ \to \ZZ$ by $x \mapsto 2x$
-		is not a ring homomomorphism.
+		is not a ring homomorphism.
 		Aside from the fact it sends $1$ to $2$,
 		it also does not preserve multiplication.
 
@@ -632,7 +632,7 @@ and tell you what the additional condition is in the next chapter.
 		For example, $\QQ[x]$, $\RR[x]$, $\CC[x]$ are PID's.
 
 		If you want to try and prove this,
-		first prove an analog of Bezout's lemma,
+		first prove an analog of Bézout's lemma,
 		which implies the result.
 
 		\ii $\CC[x,y]$ is not a PID, because $(x,y)$
@@ -660,7 +660,7 @@ Unfortunately, in certain weird rings this is also not the case.
 Nonetheless, most ``sane'' rings we work in
 \emph{do} have the property that their ideals are finitely generated.
 We now name such rings and give two equivalent definitions:
-\begin{proposition}[The equvialent definitions of a Noetherian ring]
+\begin{proposition}[The equivalent definitions of a Noetherian ring]
 	For a ring $R$, the following are equivalent:
 	\begin{enumerate}[(a)]
 		\ii Every ideal $I$ of $R$ is finitely generated


### PR DESCRIPTION
Caught one of these by hand, and then found the rest with Vim `:set spell`. I've been doing one-off commits before, but from here on, I'll batch them (but not too many at a time). 