### PR TITLE
Fix typo in galois.tex

### DIFF
--- a/tex/alg-NT/galois.tex
+++ b/tex/alg-NT/galois.tex
@@ -392,7 +392,7 @@ is the notion of a splitting field.
 \begin{definition}
 	Let $F$ be a field and $p(x) \in F[x]$ a polynomial of degree $n$.
 	Then $p(x)$ has roots $\alpha_1, \dots, \alpha_n$ in an algebraic closure of $F$.
-	The \vocab{splitting field} of $F$ is defined as $F(\alpha_1, \dots, \alpha_n)$.
+	The \vocab{splitting field} of $p(x)$ is defined as $F(\alpha_1, \dots, \alpha_n)$.
 \end{definition}
 In other words, the splitting field is the smallest field in which $p(x)$ splits.
 \begin{example}[Examples of splitting fields]

--- a/tex/alg-NT/galois.tex
+++ b/tex/alg-NT/galois.tex
@@ -392,7 +392,7 @@ is the notion of a splitting field.
 \begin{definition}
 	Let $F$ be a field and $p(x) \in F[x]$ a polynomial of degree $n$.
 	Then $p(x)$ has roots $\alpha_1, \dots, \alpha_n$ in an algebraic closure of $F$.
-	The \vocab{splitting field} of $p(x)$ is defined as $F(\alpha_1, \dots, \alpha_n)$.
+	The \vocab{splitting field} of $p(x)$ over $F$ is defined as $F(\alpha_1, \dots, \alpha_n)$.
 \end{definition}
 In other words, the splitting field is the smallest field in which $p(x)$ splits.
 \begin{example}[Examples of splitting fields]


### PR DESCRIPTION
Fix typo:  "The splitting field of F"  -->  "The splitting field of p(x) over F"