### PR TITLE
Fix typos and clarify language.

### DIFF
--- a/tex/alg-geom/zariski.tex
+++ b/tex/alg-geom/zariski.tex
@@ -321,10 +321,10 @@ For example:
 		since we can take $g_p = 1$, $f_p = f$ for every $p$.
 		So $\CC[V] \subseteq \OO_V(U)$ for any open set $U$.
 		\ii Let $V = \Aff^1$, $U_0 = V \setminus \{0\}$.
-		Then $1/x \in \OO_V(U_0)$ is regular on $U$.
+		Then $1/x \in \OO_V(U_0)$ is regular on $U_0$.
 		\ii Let $V = \Aff^1$, $U_{12} = V \setminus \{1,2\}$. Then
 		\[ \frac{1}{(x-1)(x-2)} \in \OO_V(U_{12}) \]
-		is regular on $U$.
+		is regular on $U_{12}$.
 	\end{enumerate}
 \end{example}
 The ``local'' clause with $p$'s is still necessary, though.

--- a/tex/topology/metric-prop.tex
+++ b/tex/topology/metric-prop.tex
@@ -201,11 +201,11 @@ neither are preserved under homeomorphism!
 
 This is the first hint of something going awry with the metric.
 As we progress further into our study of topology,
-we will see that in fact \emph{open and closed sets}
+we will see that in fact \emph{open sets and closed sets}
 (which we motivated by using the metric)
 are the notion that will really shine later on.
 I insist on introducing the metric first so that
-the standard pictures of open and closed sets make sense,
+the standard pictures of open sets and closed sets make sense,
 but eventually it becomes time to remove the training wheels.
 
 %It's a theorem that $\RR$ is complete.
@@ -310,7 +310,7 @@ here are two exercises to help you practice relative adjectives.
 \end{exercise}
 
 This illustrates a third point:
-a nontrivial set can be both open and closed\footnote{Which
+a nontrivial set can be both open and closed.\footnote{Which
 	always gets made fun of.}
 As we'll see in \Cref{ch:top_more}, this implies the space is disconnected;
 i.e.\ the only examples look quite like the one we've given above.

--- a/tex/topology/top-more.tex
+++ b/tex/topology/top-more.tex
@@ -3,7 +3,7 @@
 
 In \Cref{ch:metric_space} we introduced the notion
 of space by describing metrics on them.
-This gives you a lot examples, and nice intuition,
+This gives you a lot of examples, and nice intuition,
 and tells you how you should draw pictures of open and closed sets.
 
 However, moving forward, it will be useful to begin
@@ -129,7 +129,7 @@ Here was our motivating example, continuity:
 	The function is continuous if it is continuous at every point.
 \end{definition}
 
-Thus homeomorphisms carries over:
+Thus homeomorphism carries over:
 a bijection which is continuous in both directions.
 \begin{definition}
 	A \vocab{homeomorphism} of topological spaces
@@ -145,9 +145,9 @@ a bijection which is continuous in both directions.
 Therefore, any property defined only in
 terms of open sets is preserved by homeomorphism.
 Such a property is called a \vocab{topological property}.
-However, the later adjectives we define
+The later adjectives we define
 (``connected'', ``Hausdorff'', ``compact'') will all be defined
-only in terms of the open sets, so they will be.
+only in terms of open sets, so they will be topological properties.
 
 
 


### PR DESCRIPTION
These small changes are mostly typographic, but in a few locations I've made an attempt to clarify the text itself. For example, "open and closed sets" ambiguously refers to either "the property of being both open and closed" (relevant later, certainly, but not yet at this point in the text) or "the property of being open as well as the property of being closed" (which I believe you're referencing here). Similarly, I explicitly call out that "connected", "Hausdorff", and "compact" are topological properties, which was conveyed before but is hopefully easier to understand now.

Feel free to squash these commits, or to cherry-pick just the typographical changes.