### PR TITLE
Avoid ambiguity of "real"

### DIFF
--- a/tex/linalg/vector-space.tex
+++ b/tex/linalg/vector-space.tex
@@ -95,7 +95,7 @@ but first, examples\dots
 		\ii The set \[ \QQ[\sqrt 2] = \left\{ a + b \sqrt 2 \mid a, b \in \QQ \right\} \]
 		has a structure of a $\QQ$-vector space in the obvious fashion:
 		one can add any two elements, and scale by rational numbers.
-      (It is not a $\RR$-vector space, or \textit{real} vector space -- why?)
+		(It is not an $\RR$-vector space --- why?)
 		\ii The set \[ \left\{ (x,y,z) \mid x+y+z = 0 \text{ and } x,y,z \in \RR \right\} \]
 		is a $2$-dimensional real vector space.
 		\ii The set of all functions $f \colon \RR \to \RR$ is also a real vector space

--- a/tex/linalg/vector-space.tex
+++ b/tex/linalg/vector-space.tex
@@ -95,7 +95,7 @@ but first, examples\dots
 		\ii The set \[ \QQ[\sqrt 2] = \left\{ a + b \sqrt 2 \mid a, b \in \QQ \right\} \]
 		has a structure of a $\QQ$-vector space in the obvious fashion:
 		one can add any two elements, and scale by rational numbers.
-		(It is not a real vector space -- why?)
+      (It is not a $\RR$-vector space, or \textit{real} vector space -- why?)
 		\ii The set \[ \left\{ (x,y,z) \mid x+y+z = 0 \text{ and } x,y,z \in \RR \right\} \]
 		is a $2$-dimensional real vector space.
 		\ii The set of all functions $f \colon \RR \to \RR$ is also a real vector space


### PR DESCRIPTION
Consider a change similar to this.

Motivation: On two separate read throughs I read "real vector space" as "authentic vector space." I spent 10min and 30sec on this, respectively.