### PR TITLE
Fix typo in beginning of Frobenius element chapter

### DIFF
--- a/tex/alg-NT/frobenius.tex
+++ b/tex/alg-NT/frobenius.tex
@@ -13,7 +13,7 @@ Picture:
 \end{tikzcd}
 \end{center}
 If $p$ is unramified, then one can show there
-is a unique $\sigma \in \Gal(L/K)$ such that
+is a unique $\sigma \in \Gal(K/\QQ)$ such that
 $\sigma(\alpha) \equiv \alpha^p \pmod{\kp}$ for every prime $p$.
 
 \section{Frobenius elements}
@@ -29,7 +29,7 @@ Here is the theorem statement again:
 	It is called the \vocab{Frobenius element} at $\kp$, and has order $f$.
 \end{theorem}
 The \emph{uniqueness} part is pretty important:
-it allows us to show that a given $\sigma \in \Gal(L/K)$
+it allows us to show that a given $\sigma \in \Gal(K/\QQ)$
 is the Frobenius element by just observing that it satisfies
 the above functional equation.
 


### PR DESCRIPTION
The chapter starts by setting up in K/Q concretely, but then it mentions Gal(L/K).