### PR TITLE
remove-reference-to-elite-ring-commando-units

### DIFF
--- a/tex/linalg/vector-space.tex
+++ b/tex/linalg/vector-space.tex
@@ -45,7 +45,7 @@ Then informally,
 \end{moral}
 % You can think of the $R$-module as consisting of soldiers
 % being commanded by the ring $R$.
-Moreover, a \vocab{vector space} is just a module whose commanding ring
+Moreover, a \vocab{vector space} is just a module whose commutative ring
 is actually a field.
 I'll give you the full definition in a moment,
 but first, examples\dots


### PR DESCRIPTION
The first two references for `"commanding ring" linear algebra` in Google were the Napkin and notes from an Advanced Abstract Algebra course from Columbia ([link](https://www.cs.columbia.edu/~nadimpalli/data/AAL-Notes.pdf) | a screenshot is below)

<img width="1073" alt="Screen Shot 2023-06-12 at 3 52 56 PM" src="https://github.com/vEnhance/napkin/assets/14948648/40c8d4ce-7591-4aab-808c-400831285830">

<img width="1119" alt="Screen Shot 2023-06-12 at 3 55 48 PM" src="https://github.com/vEnhance/napkin/assets/14948648/8f019371-8519-4f9a-9d83-30b840b3d7fc">
