### PR TITLE
Trying to fix "transitive sets inheriting ZFC"

### DIFF
--- a/tex/set-theory/models.tex
+++ b/tex/set-theory/models.tex
@@ -352,7 +352,7 @@ true for any nonempty transitive set $M$.
 		\ii $M \vDash \Replacement$ if for every $x \in M$
 		and every function $F \colon x \to M$
 		which is $M$-definable with parameters,
-		we have $F``x \in M$ as well.
+		we have $F(x) \in M$ as well.
 		\ii $M \vDash \Infinity$ as long as $\omega \in M$.
 	\end{enumerate}
 \end{lemma}

--- a/tex/set-theory/models.tex
+++ b/tex/set-theory/models.tex
@@ -352,7 +352,7 @@ true for any nonempty transitive set $M$.
 		\ii $M \vDash \Replacement$ if for every $x \in M$
 		and every function $F \colon x \to M$
 		which is $M$-definable with parameters,
-		we have $F(x) \in M$ as well.
+		we have $F\im(x) \in M$ as well.
 		\ii $M \vDash \Infinity$ as long as $\omega \in M$.
 	\end{enumerate}
 \end{lemma}


### PR DESCRIPTION
![image](https://github.com/vEnhance/napkin/assets/5236035/79f267df-5262-46db-87c9-f18a890f45b6)

Firstly, I guess `f""x` does not look valid. I guess it is `f(x)` but I am not sure, since F already says it maps things to M.