### PR TITLE
Mention that Hermitian Matrices is a Review

### DIFF
--- a/tex/linalg/transpose.tex
+++ b/tex/linalg/transpose.tex
@@ -278,6 +278,7 @@ However, it turns out that there is
 a complete characterization of exactly when our overzealous dream is true.
 
 \begin{definition}
+	\label{def:hermitian}
 	We say a linear map $T$
 	(from a finite-dimensional inner product space to itself)
 	is \vocab{normal} if $TT^\dagger = T^\dagger T$.

--- a/tex/quantum/vectors.tex
+++ b/tex/quantum/vectors.tex
@@ -95,7 +95,7 @@ $|c_0|^2 + |c_1|^2 + \dots + |c_{n-1}|^2 = 1$.
 	since all its eigenvalues are equal,
 	but any operator with distinct eigenvalues will cause collapse.}
 If you think that's weird, well, it gets worse.
-First, some linear algebra review:
+First, some linear algebra review (\Cref{def:hermitian}):
 \begin{definition}
 	Let $V$ be a finite-dimensional inner product space.
 	For a map $T \colon V \to V$, the following conditions are equivalent:

--- a/tex/quantum/vectors.tex
+++ b/tex/quantum/vectors.tex
@@ -95,7 +95,7 @@ $|c_0|^2 + |c_1|^2 + \dots + |c_{n-1}|^2 = 1$.
 	since all its eigenvalues are equal,
 	but any operator with distinct eigenvalues will cause collapse.}
 If you think that's weird, well, it gets worse.
-First, some linear algebra:
+First, some linear algebra review:
 \begin{definition}
 	Let $V$ be a finite-dimensional inner product space.
 	For a map $T \colon V \to V$, the following conditions are equivalent:


### PR DESCRIPTION
One word change, but here's some justification. Quantum algorithm section depends on Lin alg, and most of the quantum part on lin alg is direct review for an earlier section. Deleting this entire section and linking back to the original section also works, but seems like a lot of work. Plus, review is always nice. So mentioning that this is review is a nice compromise.