### PR TITLE
Various changes

### DIFF
--- a/tex/alg-geom/sheaves.tex
+++ b/tex/alg-geom/sheaves.tex
@@ -524,7 +524,7 @@ Now for the examples.
 
 		\ii Let $X = \RR$, and define the presheaf of rings $\SF$ by:
 		\[
-			\SF(U) = \{ f \colon U \to \RR: \text{there exists continuous $g
+			\SF(U) = \{ f \colon U \to \RR \mid \text{there exists continuous $g
 			\colon \RR \to \RR$ such that $g\restrict{U} = f$} \}.
 		\]
 		Then $\SF$ is not a sheaf. Indeed, $s_1(x) = 0$ in $\SF((-1, 0))$

--- a/tex/cats/abelian.tex
+++ b/tex/cats/abelian.tex
@@ -104,6 +104,12 @@ which are the types of categories where this notion is most useful.
 		The zero map serves as the identity element for each group.
 \end{itemize}
 \end{definition}
+In short:
+\begin{moral}
+	In an additive category, you can add two morphisms.
+\end{moral}
+Which is the only definition that makes sense anyway, we cannot talk about elements.
+
 \begin{definition}
 	An \vocab{abelian category} $\AA$ is one with the additional properties that
 	for any morphism $A \taking f B$,
@@ -135,6 +141,9 @@ which are the types of categories where this notion is most useful.
 		a commutative addition to pairs of morphisms.
 	\end{enumerate}
 \end{example}
+
+From now on, you can basically forget about additive category, we will be working in abelian
+category.
 
 In general, once you assume a category is abelian, all the properties you would want
 of these kernels, cokernels, \dots\ that you would guess hold true.
@@ -181,6 +190,7 @@ For example,
 \end{proof}
 
 \section{Exact sequences}
+\label{sec:exact_sequences}
 \prototype{$0 \to G \to G \times H \to H \to 0$ is exact.}
 Exact sequences will seem exceedingly unmotivated until you learn about homology groups,
 which is one of the most natural places that exact sequences appear.
@@ -207,6 +217,31 @@ We say the entire sequence is exact if it's exact at $k=1,\dots,n-1$.
 		\ii For groups, the map $0 \to A \to B$ is exact if and only if $A \to B$ is injective.
 		\ii For groups, the map $A \to B \to 0$ is exact if and only if $A \to B$ is surjective.
 	\end{enumerate}
+\end{example}
+
+If you look at the prototypical example, actually, a \vocab{short exact sequence} (an exact sequence
+of the form $0 \to A \to B \to C \to 0$) is the most natural things ever:
+\begin{moral}
+	It's basically just an equation $C = B/A$.
+\end{moral}
+Whenever you see ``there is a short exact sequence $0 \to A \to B \to C \to 0$'', you
+can mentally translate it to ``$C \cong B/A$''; but there's a slight difference:
+A group has more structures than a number, so the sequence also contains the information of the
+maps --- the map that identifies $A$ with a subgroup of $B$, and the map that identifies $C$
+with the quotient group $B/A$.
+\begin{example}[More exact sequences]
+	\listhack
+	\begin{enumerate}[(a)]
+		\ii The sequence
+			\[ 0 \to \ZZ \taking{\times 3} \ZZ \to \Zc{3} \to 0 \]
+		is short exact.
+		\ii So is
+			\[ 0 \to \ZZ \taking{\times 5} \ZZ \to \Zc{5} \to 0. \]
+	\end{enumerate}
+	As you can see, the written equation ``$C \cong B/A$'' is not completely accurate, the map $A
+	\to B$ also matters in determining what $C$ is. This also explains the common notation: the
+	image of the map $\ZZ \taking{\times 3} \ZZ$ is usually written $3 \ZZ$, thus $\Zc{3} =
+	\frac{\ZZ}{3 \ZZ}$.
 \end{example}
 
 Now, we want to mimic this definition in a general \emph{abelian} category $\AA$.
@@ -450,3 +485,21 @@ where $C_k = \img f_{k-1} = \ker f_k$ for every $k$.
 	Prove that there is an exact sequence
 	\[ \Ker a \to \Ker b \to \Ker c \to \Coker a \to \Coker b \to \Coker c. \]
 \end{sproblem}
+
+\begin{problem}
+	[An additive category that is not abelian]
+	Consider a category, where:
+	\begin{itemize}
+		\ii the objects are pairs of abelian groups $(B, A)$ where $A$ is a subgroup of $B$.
+		\ii the morphisms $(B, A) \to (B', A')$ are maps $f \colon B \to B'$ where
+		$f\im(A) \subseteq A'$.
+	\end{itemize}
+	(You can think of this similar to the $\catname{PairTop}$ category, seen in
+	\Cref{ch:relative_hom}. We use abelian groups here to make the category additive.)
+
+	This category can be equivalently viewed as the category of short exact sequences
+	$0 \to A \to B \to B/A \to 0$ of abelian groups.
+
+	Show that the arrow $(X, 0) \to (X, X)$ is monic and epic, but not an
+	isomorphism. Conclude that the category is not abelian.
+\end{problem}

--- a/tex/cats/functors.tex
+++ b/tex/cats/functors.tex
@@ -506,6 +506,8 @@ where the component $\eps_V$ is given by $v \mapsto \opname{ev}_v$
 the fact that it is an isomorphism follows from the fact that $V$ and $(V^\vee)^\vee$
 have equal dimensions and $\eps_V$ is injective).
 
+Another example can be found in \Cref{remark:hurewicz}.
+
 \section{(Optional) The Yoneda lemma}
 Now that I have natural transformations, I can define:
 \begin{definition}
@@ -603,7 +605,9 @@ and refer you to \cite{ref:msci} for the proofs.
 	Each $A$ gives us some information on how $X$ and $Y$ are similar,
 	but the whole natural isomorphism is strong enough to imply $X \cong Y$.
 
-	\ii Consider the functor $U \colon \catname{Grp} \to \catname{Set}$.
+	\ii Consider the covariant forgetful functor $U \colon \catname{Grp} \to
+	\catname{Set}$.\footnote{Actually, you need to apply a dual version.
+	\Cref{thm:yoneda} uses contravariant functor.}
 	It can be represented by $H^\ZZ$, in the sense that
 	\[ \Hom_{\catname{Grp}}(\ZZ, G) \cong U(G)
 		\qquad\text{ by }\qquad \phi \mapsto \phi(1). \]

--- a/tex/diffgeo/manifolds.tex
+++ b/tex/diffgeo/manifolds.tex
@@ -547,8 +547,8 @@ Using some real analysis, one can prove the following result:
 	Then
 	\[
 	\begin{aligned}
-		\km_0 &= \{ \text{smooth functions } f \colon f(0) = 0 \} \\
-		\km_0^2 &= \{ \text{smooth functions } f \colon f(0) = 0, (\nabla f)_0 = 0 \}.
+		\km_0 &= \{ \text{smooth functions } f \mid f(0) = 0 \} \\
+		\km_0^2 &= \{ \text{smooth functions } f \mid f(0) = 0, (\nabla f)_0 = 0 \}.
 	\end{aligned}
 	\]
 	In other words $\km_0^2$ is the set of functions which vanish at $0$

--- a/tex/homology/cohomology.tex
+++ b/tex/homology/cohomology.tex
@@ -308,6 +308,67 @@ you can pick any free resolution you want and compute the above.
 	$\Ext(\ZZ^{\oplus 2015}, G)$ and $\Ext(\Zc{30}, \Zc 4)$.
 \end{ques}
 
+\section{Explanation for universal coefficient theorem}
+
+There is so much unexplained symbols and formulas in the previous chapter that may make you scream:
+\begin{quote}
+	I don't care if $\CP^2$ and $S^2 \vee S^4$ are distinct anymore! What are these spaces anyway?
+\end{quote}
+Nevertheless, it is not all that difficult. There are two key points to be read from the theorem:
+\begin{itemize}
+	\ii Even though $H_n(A_\bullet) = 0$, it is still possible for $H^n(A_\bullet; G) \neq 0$
+	if $\Ext(H_{n-1}(A_\bullet), G) \neq 0$.
+
+	In low-dimensional cases, we can actually visualize it --- \Cref{sec:visual_cohom_groups}
+	does that for the Klein bottle.
+	\ii $H^n(A_\bullet; G)$ is uniquely determined by $H_n(A_\bullet)$ and $G$, regardless of what
+	$A_\bullet$ is, as long as each $A_n$ is free.
+\end{itemize}
+
+Which means: if you wish, you can forget about the formula in the universal coefficient theorem,
+and use the cellular chain complex $\Cells_\bullet(X)$ to compute cohomology by:
+\[ H^n(X; G) = \frac{\ker(\Hom(\Cells_n(X), G) \to \Hom(\Cells_{n+1}(X), G))}
+{\img(\Hom(\Cells_{n-1}(X), G) \to \Hom(\Cells_{n}(X), G))}. \]
+After all, the cellular chain complex and the singular chain complex are both free and have the same
+homology groups, so by the universal coefficient theorem they must have the same cohomology groups.
+
+Nevertheless, the formula of the universal coefficient theorem is desirable because, more often than
+not, the chain complex $A_\bullet$ is more complicated than $H_\bullet(A_\bullet)$.
+
+\begin{example}
+	The Klein bottle's cellular chain complex has the following form:
+	\[ \cdots \to \ZZ \taking{1 \mapsto (0, 2)} \ZZ^2 \taking {(a, b) \mapsto 0} \ZZ. \]
+	The homology groups is:
+	\[ H_2 = 0, H_1 = \ZZ \oplus \Zc{2}, H_0 = \ZZ. \]
+	It's indeed simpler, but only marginally (there are $3$ generators instead of $4$, and we don't
+	need to keep track of the maps)
+	because cellular homology is already so efficient.
+\end{example}
+
+Where does the formula come from, again? You can think of it like this.
+Because the universal coefficient theorem tells us that $H^\bullet(A_\bullet; G)$ only depends on
+$H_\bullet(A_\bullet)$, if we're given $H_\bullet$, we just construct \emph{any} chain complex of
+free abelian groups $A_\bullet$ and dualize it.
+
+Assume $H_k = 0$ for every terms, except $H_{n-1}\neq 0$. Then, tautologically,
+$H^n \cong \Ext(H_{n-1}; G)$ --- a free resolution \emph{is} a chain complex!
+
+\begin{exercise}
+	Verify this. (Hint: Starting from the exact sequence $Z_{n-1} \to H_{n-1} \to 0$.
+	Can you extend it to a free resolution of $H_{n-1}$?)
+\end{exercise}
+
+Assume $H_k = 0$ for every terms, except $H_n \neq 0$. Then we can see $H^n \cong \Hom(H_n, G)$.
+
+The universal coefficient theorem simply states that the choice of free resolution doesn't matter,
+and that if the other terms can be nonzero, $H^n$ is the direct sum of the two groups in the two
+cases above.
+
+If you want, you can even prove the fact that the choice of free resolution does not matter yourself
+--- it's a bit tricky, but not all that difficult. It boils down to the construction of maps
+between the chain complexes (it's not difficult to ensure the diagram commutes, the groups are free
+so we can send the basis wherever we want), and show the two free resolutions are chain homotopic.
+
 \section{Example computation of cohomology groups}
 \prototype{Possibly $H^n(S^m)$.}
 
@@ -397,6 +458,7 @@ From these examples one might notice that:
 \end{example}
 
 \section{Visualization of cohomology groups}
+\label{sec:visual_cohom_groups}
 
 We try to make sense of $C^n(X; G)$ and $H^n(X; G)$, for higher values of $n$.
 
@@ -461,10 +523,11 @@ Let us see what a $n$-cocycle must look like. First,
 \begin{moral}
 	Homotopic chains with the same boundary are mapped to the same value by cocycles.
 \end{moral}
-We defined what it means for two $k$-simplex to be homotopic in \Cref{sec:higher_homotopy_grps} ---
-in the current situation, we require in addition that the boundaries are always fixed.
+We defined what it means for two $k$-simplices to be homotopic in \Cref{sec:higher_homotopy_grps}
+--- in the current situation, we require in addition that the boundaries are always fixed.
 
-For instance, the blue and the orange $1$-simplex below are homotopic, but not the red $1$-simplex.
+For instance, the blue and the orange $1$-simplices below are homotopic, but not the red
+$1$-simplex.
 \begin{center}
 \begin{asy}
 	size(4cm);
@@ -481,7 +544,7 @@ For instance, the blue and the orange $1$-simplex below are homotopic, but not t
 \end{center}
 
 Proof is not difficult --- you just need to show that the difference between two homotopic
-$k$-simplex is the boundary of something (their interior!), and write the interior as the
+$k$-simplices is the boundary of something (their interior!), and write the interior as the
 sum of some $k+1$-simplices. (Hint: The easiest way is actually to write the interior as the
 difference of two $k+1$-simplices instead, and be careful of vertex ordering issues.)
 \begin{exercise}

--- a/tex/homology/excision.tex
+++ b/tex/homology/excision.tex
@@ -21,8 +21,7 @@ and use this to make deductions.
 
 The main motivation is that:
 \begin{moral}
-	Relative homology is the algebraic topology analog of quotient homology.
-	% (or analogue?)
+	Relative homology is the algebraic analog of quotient space.
 \end{moral}
 So, for instance, when you see a map of pairs
 $f \colon (X, A) \to (Y, B)$, you should think of $X/A \to Y/B$.
@@ -104,8 +103,8 @@ Even when $A$ is closed in $X$, problems can still happen.
 	``finitely many circles'' (or all but finitely many).
 
 	We haven't had enough tools to formalize all these yet.
-	Formally speaking, the quotient map $q \colon X \to X/A$ and $q \colon A \to A/A$ induces $q_*
-	\colon H(X, A) \to H(X/A, A/A)$, and $q_*$ is not injective.
+	Formally speaking, the quotient maps $q \colon X \to X/A$ and $q \colon A \to A/A$ induces $q_*
+	\colon H_1(X, A) \to H_1(X/A, A/A)$, and $q_*$ is not injective.
 \end{example}
 
 Regardless, for nice spaces $A \subseteq X$ such that $H_n(X, A) \cong \wt H_n(X/A)$, we would be

--- a/tex/homology/long-exact.tex
+++ b/tex/homology/long-exact.tex
@@ -46,6 +46,12 @@ It is said to be \vocab{short exact} if \emph{each row} of the diagram below is 
 \end{center}
 \end{definition}
 
+\begin{moral}
+	This basically means $C_\bullet = B_\bullet / A_\bullet$, for suitable definition of
+	$/$ on chain complexes.
+\end{moral}
+This agrees with the definition in \Cref{sec:exact_sequences}.
+
 \begin{example}
 	[Mayer-Vietoris short exact sequence and its augmentation]
 	\label{ex:mayer_short_exact}

--- a/tex/homology/singular.tex
+++ b/tex/homology/singular.tex
@@ -252,6 +252,38 @@ and the boundaries (in $B_1(X)$, i.e.\ the things we mod out by)
 are exactly the nulhomotopic loops in $\pi_1(X, x_0)$.
 The difference is that $H_1(X)$ allows loops to commute,
 whereas $\pi_1(X, x_0)$ does not.
+
+\begin{remark}[Digression: category theory interpretation]
+	\label{remark:hurewicz}
+	From this, you can say that there is a Hurewicz map $\pi_1(X, x_0) \taking\phi H_1(X)$
+	for each $(X, x_0)$.
+
+	But there is more than that: this map is \emph{natural}, in the sense that for $h \colon (X,
+	x_0) \to (Y, y_0)$ map of pointed spaces, then
+	\begin{center}
+		\begin{tikzcd}
+			\pi_1(X, x_0) \rar["h_\sharp"] \dar["\phi"] & \pi_1(Y, y_0) \dar["\phi"] \\
+			H_1(X) \rar["h_\ast"] & H_1(Y) \\
+		\end{tikzcd}
+	\end{center}
+	commutes.
+
+	In category theory terms, we say that $\phi$ is a \emph{natural transformation}
+	from $\pi_1$ to $H_1$.
+
+	Another way to say this is: we have families of groups
+	\[ \{ \pi_1(X, x_0) \mid (X, x_0)\text{ pointed space} \} \]
+	and
+	\[ \{ H_1(X) \mid (X, x_0)\text{ pointed space} \} \]
+	then the natural transformation $\phi$ can be seen as a family of homomorphisms
+	\[ \{ \phi \colon \pi_1(X, x_0) \to H_1(X) \mid (X, x_0)\text{ pointed space} \} \]
+	satisfying the naturality conditions.
+
+	Of course, the fact that $\pi_1$ is a functor means
+	$\{ \pi_1(X, x_0) \mid (X, x_0)\text{ pointed space} \}$ is a lot more than a family of groups
+	indexed by pointed spaces, as explained in \Cref{thm:fundgrp_functor}.
+\end{remark}
+
 \begin{example}
 	[The first homology group of the annulus]
 	To give a concrete example, consider the annulus $X$ above.

--- a/tex/measure/martingale.tex
+++ b/tex/measure/martingale.tex
@@ -98,9 +98,9 @@ Here are some more serious examples.
 		variable taking on one of three values.
 		If we're interested in $X$ then we could define
 		\begin{align*}
-			A &= \{\omega \colon X(\omega) = 1\} \\
-			B &= \{\omega \colon X(\omega) = 2\} \\
-			C &= \{\omega \colon X(\omega) = 3\}
+			A &= \{\omega \mid X(\omega) = 1\} \\
+			B &= \{\omega \mid X(\omega) = 2\} \\
+			C &= \{\omega \mid X(\omega) = 3\}
 		\end{align*}
 		then we could write
 		\[ \SF = \left\{ \varnothing, \; A, \; B, \; C, \;

--- a/tex/measure/pontryagin.tex
+++ b/tex/measure/pontryagin.tex
@@ -62,8 +62,8 @@ The relevant theorem, which we will just quote:
 		That means that $\mu$ is ``translation-invariant''
 		under translation by $G$.
 		\ii $\mu(K)$ is finite for any compact set $K$.
-		\ii if $S$ is measurable, then $\mu(S) = \inf\left\{ \mu(U) \colon U \supseteq S \text{ open} \right\}$.
-		\ii if $U$ is open, then $\mu(U) = \sup\left\{ \mu(S) \colon S \supseteq U \text{ measurable} \right\}$.
+		\ii if $S$ is measurable, then $\mu(S) = \inf\left\{ \mu(U) \mid U \supseteq S \text{ open} \right\}$.
+		\ii if $U$ is open, then $\mu(U) = \sup\left\{ \mu(S) \mid S \supseteq U \text{ measurable} \right\}$.
 	\end{itemize}
 	Moreover, it is unique up to scaling by a positive constant.
 \end{theorem}

--- a/tex/riemann-surface/complex-structure.tex
+++ b/tex/riemann-surface/complex-structure.tex
@@ -209,7 +209,7 @@ Of course, by the miracle of complex analysis --- holomorphic functions are anal
 equivalent to stating that a Riemann surface carries a complex-analytic structure.
 
 \section{Riemann surface}
-\prototype{The Riemann sphere, or any open subset of $\CC$ such as $\{ z \in \CC: |z| < 1 \}$.}
+\prototype{The Riemann sphere, or any open subset of $\CC$ such as $\{ z \in \CC \mid |z| < 1 \}$.}
 
 From the motivation above, the definition of a Riemann surface naturally falls out:
 \begin{definition}[Riemann surface]

--- a/tex/set-theory/CH.tex
+++ b/tex/set-theory/CH.tex
@@ -308,12 +308,12 @@ This is purely combinatorial, and so we work briefly.
 \end{lemma}
 \begin{proof}
 	Assume not. Let
-	\[ \left\{ p_\alpha \colon \alpha < \omega_1 \right\} \]
+	\[ \left\{ p_\alpha \mid \alpha < \omega_1 \right\} \]
 	be a strong antichain.  Let
-	\[ C = \left\{ \dom(p_\alpha) \colon \alpha < \omega_1 \right\}. \]
+	\[ C = \left\{ \dom(p_\alpha) \mid \alpha < \omega_1 \right\}. \]
 	Let $\ol C \subseteq C$ be such that $\ol C$ is uncountable, and $\ol C$ is a $\Delta$-system with root $R$.
 	Then let
-	\[ B = \left\{ p_\alpha \colon \dom(p_\alpha) \in R \right\}. \]
+	\[ B = \left\{ p_\alpha \mid \dom(p_\alpha) \in R \right\}. \]
 	Each $p_\alpha \in B$ is a function $p_\alpha \colon R \to \{0,1\}$,
 	so there are two that are the same.
 \end{proof}

--- a/tex/topology/cover-project.tex
+++ b/tex/topology/cover-project.tex
@@ -61,7 +61,19 @@ A much more interesting example is that of $\RR$ and $S^1$.
 	This is essentially wrapping the real line
 	into a single helix and projecting it down.
 \end{example}
-\missingfigure{helix}
+\begin{center}
+	\begin{asy}
+		var flatten = yscale(0.4);
+		guide g;
+		for (real a=90+360*5; a>=90; a-=20){
+			g = g .. flatten*dir(a)+(0, a/360/3);
+		}
+		draw(g, Arrows);
+		draw((0, -0.4)--(0, -1.4), Arrow, L=Label("$p$"));
+		draw(shift(0, -2)*flatten*unitcircle, L=Label("$S^1$", Relative(0.1)));
+	\end{asy}
+\end{center}
+
 
 We claim this is a covering projection.
 Indeed, consider the point $1 \in S^1$
@@ -254,13 +266,13 @@ where $Y$ is some general path-connected space, as follows.
 	and consider a covering projection $p \colon (E, e_0) \to (B, b_0)$.
 	(As usual, $Y$, $B$, $E$ are path-connected.)
 	Then a lifting $\tilde f$ with $\tilde f(y_0) = e_0$ exists if and only if
-	\[ f_\ast\im(\pi_1(Y, y_0)) \subseteq p_\ast\im(\pi_1(E, e_0)), \]
+	\[ f_\sharp\im(\pi_1(Y, y_0)) \subseteq p_\sharp\im(\pi_1(E, e_0)), \]
 	i.e.\ the image of $\pi_1(Y, y_0)$ under $f$ is contained in
 	the image of $\pi_1(E, e_0)$ under $p$ (both viewed as subgroups of $\pi_1(B, b_0)$).
 	If this lifting exists, it is unique.
 \end{theorem}
-As $p_\ast$ is injective,
-we actually have $p_\ast\im(\pi_1(E, e_0)) \cong \pi_1(E, e_0)$.
+As $p_\sharp$ is injective,
+we actually have $p_\sharp\im(\pi_1(E, e_0)) \cong \pi_1(E, e_0)$.
 But in this case we are interested in the actual elements, not just the isomorphism classes of the groups.
 \begin{ques}
 	What happens if we put $Y= [0,1]$?

--- a/tex/topology/fundamental-group.tex
+++ b/tex/topology/fundamental-group.tex
@@ -354,7 +354,7 @@ fundamental groups.
 This is the ``usual'' definition of simply connected.
 
 
-\section{Fundamental groups are functorial}
+\section{Fundamental groups are invariant under homeomorphism}
 One quick shorthand I will introduce to clean up the discussion:
 \begin{definition}
 	By $f \colon (X, x_0) \to (Y, y_0)$, we will mean that
@@ -561,7 +561,7 @@ and bending than homeomorphism: we are allowed to compress huge spaces into sing
 	the same is not true for $\CC \setminus \{0\}$.
 \end{remark}
 \begin{example}
-	[$\text{Disk} = \text{Point}$, $\text{Annulus} = \text{Circle}$.]
+	[$\text{Disk} = \text{Point}$, $\text{Annulus} = \text{Circle}$]
 	By the same token, a disk is homotopic to a point;
 	an annulus is homotopic to a circle.
 	(This might be a little easier to visualize, since it's finite.)
@@ -610,7 +610,8 @@ the content of this chapter using categorical notions.
 \begin{definition}
 	The \vocab{pointed homotopy category} $\catname{hTop}_\ast$ is defined as follows.
 	\begin{itemize}
-		\ii Objects: pairs $(X, x_0)$ of spaces with a distinguished basepoint, and
+		\ii Objects: \vocab{pointed spaces}; that is, a pair $(X, x_0)$ of spaces $X$ with a
+		distinguished basepoint $x_0$, and
 		\ii Morphisms: \emph{homotopy classes} of continuous functions $(X, x_0) \to (Y, y_0)$.
 	\end{itemize}
 \end{definition}
@@ -629,19 +630,20 @@ Then we can summarize many of the preceding results as follows:
 	\end{tikzcd}
 	\end{center}
 \end{theorem}
-This implies several things, like
+The fact that $\pi_1$ is a functor instead of merely assigns some group $\pi_1(X, x_0)$
+to each pointed topological space $(X, x_0)$ automatically implies several nice things, like:
 \begin{itemize}
 	\ii The functor bundles the information of $f_\sharp$,
 	including the fact that it respects composition.
 	In the categorical language, $f_\sharp$ is $\pi_1(f)$.
-	\ii Homotopic spaces have isomorphic fundamental group
+	\ii Homotopic spaces have isomorphic fundamental groups
 	(since the spaces are isomorphic in $\catname{hTop}$,
 	and functors preserve isomorphism by \Cref{thm:functor_isom}).
 	In fact, you'll notice that the proofs
 	of \Cref{thm:functor_isom} and \Cref{thm:fundgrp_homotopy_invariant}
 	are secretly identical to each other.
 	\ii If maps $f, g \colon (X, x_0) \to (Y, y_0)$ are homotopic,
-	then $f_\sharp = g_\sharp$. This is basically \Cref{lem:fsharp_homotopy_invariant}
+	then $f_\sharp = g_\sharp$. This is basically \Cref{lem:fsharp_homotopy_invariant}.
 \end{itemize}
 
 \begin{remark}


### PR DESCRIPTION
* Make notation consistent: use `|` instead of `:` for set comprehension (expect for `{f: A → B | f satisfies some condition}`), and `#` instead of `*` for induced map between fundamental group (isn't life simpler if both use `*`?)
* Category theory: Add explicit example for natural transformation (slightly illuminating for me, although the first real application for functor and natural transformation I see is the method of acyclic model... which so far I know of exactly one application, to prove `H_●(A × B) ≅ H_●(A) ⊗ H_●(B) ⊗ torsion terms` i.e. Künneth formula for homology, but I do see that the abstract nonsense is slightly more elegant than explicitly constructing the EZ and AW maps --- the construction of AW map even involves some arbitrary unexplained choices)
* Category theory: Add some intuition for additive category (hopefully this is useful, but I still don't know why is an additive category **defined** at all) and short exact sequence
* Algebraic topology: Add some explanation for Ext functor (really, "why should I care about distinguishing these spaces anyway?" was my impression on several initial read-through.) (even though I write there it is not too difficult to work out the proof by constructing chain homotopy, I haven't worked it out myself either...)
* Minor grammar fixes (mostly caused by my additions in previous pull requests...)

-------

I don't remember if the intuition for short exact sequence is already explained somewhere, but it feels like it should be ("it's so obvious in retrospect!" — I suppose.)