### PR TITLE
Increase tocpagenumberwidth

### DIFF
--- a/tex/preamble.tex
+++ b/tex/preamble.tex
@@ -251,8 +251,9 @@ style=thmbluebox,name=Theorem,numberwithin=section]{theorem}
 \makeatother
 \setcounter{tocdepth}{1}
 \RedeclareSectionCommand[tocnumwidth=4.2em]{part}
-\RedeclareSectionCommand[tocnumwidth=4.2em]{chapter}
-\RedeclareSectionCommand[tocnumwidth=2.8em]{section}
+\RedeclareSectionCommand[tocpagenumberwidth=2.2em,tocnumwidth=4.2em]{chapter}
+\RedeclareSectionCommand[tocpagenumberwidth=2.2em,tocnumwidth=2.8em]{section}
+% adjust tocpagenumberwidth manually for large page number: https://tex.stackexchange.com/a/502168
 
 %%fakesection Asymptote definitions
 \usepackage{patch-asy}


### PR DESCRIPTION
Otherwise the page numbers in the ToC will be misaligned.

![image](https://github.com/vEnhance/napkin/assets/25191436/5f0d60fa-2b12-4403-ac94-99c0c8c07cf8)

Before:

![image](https://github.com/vEnhance/napkin/assets/25191436/589a17e5-7a20-4a1b-abc0-8b5fdf9ebf4a)

After:

![image](https://github.com/vEnhance/napkin/assets/25191436/92b17480-5555-407b-839b-0d36810b057d)

(One dot is missing though. But I think it doesn't matter that much.)

Strangely enough setting it to 1.7em lead to this bug.

![image](https://github.com/vEnhance/napkin/assets/25191436/0eb19d82-29d0-4a26-9ced-0a8385f9c85f)

I suspect some pdflatex's bug… (though it will actually take forever to investigate)