### PR TITLE
Change "less than" to "less than or equal"

### DIFF
--- a/tex/alg-NT/dedekind.tex
+++ b/tex/alg-NT/dedekind.tex
@@ -314,7 +314,7 @@ Okay, I'll just say it now!
 	and this factorization is unique up to the order of the $\kp_i$.
 
 	Moreover, $\ka$ divides $\kb$ if and only if for every prime ideal $\kp$,
-	the exponent of $\kp$ in $\ka$ is less than the corresponding exponent in $\kb$.
+	the exponent of $\kp$ in $\ka$ is less than or equal to the corresponding exponent in $\kb$.
 \end{theorem}
 %% Ofer joke
 % As ideals, you and I are coprime because together we are (1).


### PR DESCRIPTION
I believe this is a typo - for example (6) divides (6) and (3) divides (6).