### PR TITLE
Correct a minor grammatical mistake ("a semisimple")

### DIFF
--- a/tex/rep-theory/semisimple.tex
+++ b/tex/rep-theory/semisimple.tex
@@ -297,7 +297,7 @@ This also gives us the non-obvious corollary:
 
 \section{Semisimple algebras}
 \begin{definition}
-	A finite-dimensional algebra $A$ is a \vocab{semisimple}
+	A finite-dimensional algebra $A$ is \vocab{semisimple}
 	if every finite-dimensional representation of $A$ is completely reducible.
 \end{definition}
 


### PR DESCRIPTION
*Semisimple* is not a noun, I believe.