### PR TITLE
Fix a typo

### DIFF
--- a/tex/measure/swapsum.tex
+++ b/tex/measure/swapsum.tex
@@ -185,7 +185,7 @@ Here is the so-called ``monotone convergence theorem''.
 		&\le \int_\Omega f \; d\mu
 	\end{align*}
 	where the first $\le$ is by Fatou lemma,
-	and the second by the fact that
+	and the third by the fact that
 	$\int_\Omega f_n \le \int_\Omega f$ for every $n$.
 	This implies all the inequalities are equalities and we are done.
 \end{proof}


### PR DESCRIPTION
Fixes a typo in the proof of Monotone convergence theorem.
The second $\le$ is $\liminf \le \limsup$ like in the proof of Fatou–Lebesgue theorem, the third $\le$ is the one that uses $\int_\Omega f_n \le \int_\Omega f$.