### PR TITLE
fix: statement and hint of problem 16E

### DIFF
--- a/tex/H113/action.tex
+++ b/tex/H113/action.tex
@@ -328,18 +328,20 @@ A trivial result that gets used enough that I should explicitly call it out:
 \begin{dproblem}
 	[Classical]
 	\gim
-	Assume $G$ is a finite group and $p$ is the smallest prime dividing its order.
-	Let $H$ be a subgroup of $G$ with $\left\lvert G \right\rvert / \left\lvert H \right\rvert = p$.
+    Assume $G$ is a finite group of order $n \ge 2$ and $p$ is the
+    smallest prime dividing $n$. Let $H$ be a subgroup of $G$ with
+    $\left\lvert G \right\rvert / \left\lvert H \right\rvert = p$.
 	Show that $H$ is normal in $G$.
-	\begin{hint}
-		Let $G$ act on the left cosets $\{gH \mid g \in G\}$
-		by left multiplication: $g' \cdot gH = g'gH$.
-		Consider the orbit $\OO$ of the coset $H$.
-		By the orbit-stabilizer theorem, $\left\lvert \OO \right\rvert$ divides $\left\lvert G \right\rvert$.
-		But $\left\lvert \OO \right\rvert \le p$ also.
-		So either $\OO = \{H\}$ or $\OO$ contains all cosets.
-		The first case is impossible.
-	\end{hint}
+    \begin{hint}
+        Let $H$ act on the left cosets $\{gH \mid g \in G\}$
+        by left multiplication: $h \cdot gH = hgH$.
+        Consider any orbit $\OO$
+        By the orbit-stabilizer theorem, $\left\lvert \OO \right\rvert$
+        divides $\left\lvert H \right\rvert$ which divides $n$, so $\OO$
+        divides $n$. But $\left\lvert \OO \right\rvert \le p$ since
+        there are $p$ cosets. So either $\OO = \{H\}$ or $\OO$ contains
+        all cosets. Show that the latter is impossible and conclude.
+    \end{hint}
 	\begin{sol}
 		\url{https://math.stackexchange.com/a/3012179/229197}
 	\end{sol}


### PR DESCRIPTION
First of all added the condition for $n \ge 2$ so that there is a prime that divides $|G|$. 

More importantly, I think there is a mistake on the hint. You say that you should consider $G$ acting on the left cosets of $H$. This is one of possible solutions, but I don't think you meant that one, because the solutions in which you consider $G$ as the group that acts on cosets, you conclude by getting a morfism from $G$ to $S_p$ and do something with factorias. You also  consider the orbit of $H$ for some reason and apply the orbit stabilizer theorem to deduce something about its orbit, but you obviously don't need this because the orbit of $H$ under this particular action gives you all of the cosets (to get $g H$ just multiply by $g$). Finally, in the solution you provided, the group that acts on cosets is $H$, so you probably got confused while writing the solution.

So basically, I added $n \ge 2$ for the order of $G$, changed the hint to "Let $H$ act on left cosets" and then more or less indicated the path of the solution from there. The point is that you use the orbit stabilizer theorem on *all* orbits to show that either there is only one orbit or all orbits have size 1. Since the first case cannot happen (because the orbit of $H$ is ${H}$ which is not all the cosets) then all orbits must have size 1 and thus $h g H = g H$ for all $h \in H$ and $g \in G$, which implies that $H$ is normal.