### PR TITLE
fix: typos and changed the Sylow proof

### DIFF
--- a/tex/H113/sylow.tex
+++ b/tex/H113/sylow.tex
@@ -142,7 +142,7 @@ By considering the set $X$ of ALL subsets of size $p^n$ at once, we can exploit 
 
 Here is the proof.
 \begin{itemize}
-	\ii Let $G$ act on $X$ by $g \cdot X \defeq \left\{ gx \mid x \in X \right\}$.
+	\ii Let $G$ act on $X$ by $g \cdot S \defeq \left\{ gs \mid s \in S \right\}$.
 	\ii Take an orbit $\OO$ with size not divisible by $p$.
 	(This is possible because of our deep number theoretic fact.
 	Since $\left\lvert X \right\rvert$ is nonzero mod $p$ and the orbits partition $X$,
@@ -159,10 +159,10 @@ Here is the proof.
 
 
 \subsection{Step 2: Any two Sylow $p$-subgroups are conjugate}
-Let $P$ be a Sylow $p$-subgroup (which exists by the previous step).
-We now prove that for any $p$-group $Q$, $Q \subseteq gPg\inv$.
-Note that if $Q$ is also a Sylow $p$-subgroup, then $Q = gPg\inv$ for size reasons;
-this implies that any two Sylow subgroups are indeed conjugate.
+If $P$ is a Sylow $p$-subgroup and $Q$ is a $p$-group, we prove $Q
+\subseteq gPg\inv$. Note that if $Q$ is also a Sylow $p$-subgroup, then
+$Q = gPg\inv$ for size reasons; this implies that any two Sylow
+subgroups are indeed conjugate.
 
 \textbf{Let $Q$ act on the set of left cosets of $P$ by left multiplication.}
 Note that
@@ -176,15 +176,14 @@ Equivalently, $qg \in gP$ for all $q \in Q$, so $Q \subseteq gPg\inv$ as desired
 
 
 \subsection{Step 3: Showing $n_p \equiv 1 \pmod p$}
-Let $\mathcal S$ denote the set of all the Sylow $p$-subgroups.
-Let $P \in \mathcal S$ be arbitrary.
+Let $\mathcal S$ denote the set of all the Sylow $p$-subgroups. By our
+first step, there exists some $P \in \mathcal S$.
 \begin{ques}
 	Why does $\left\lvert \mathcal S \right\rvert$ equal $n_p$?
 	(In other words, are you awake?)
 \end{ques}
-Now we can proceed with the proof.
-Let $P$ act on $\mathcal S$ by conjugation.
-Then:
+Now we can proceed with the proof. Let $P$ act on $\mathcal S$ by
+conjugation. Then:
 \begin{itemize}
 	\ii Because $P$ is a $p$-group, $n_p \pmod p$ is the number of fixed points
 	of this action.


### PR DESCRIPTION
- Corrected a typo, because $G$ acts on $X$, which is a set of subsets of G, and you used the letter $X$ for an element of $X$. I changed it to $g \cdot S = \\{ g s \mid s \in S \\}$. 
- Second of all, you don't actually need step 1 in step 2. You are just proving the statement "given some Sylow $p$-subgroup and any $p$-subgroup, this happens ...".
- The existence of $P$ is actually necessary for step $3$, because you have to take some specific $P$ and use the orbit stabilizer theorem with it, so I moved the phrase that remarks the usefulness of step 1 to step 3 and removed it from step 2.
