### PR TITLE
fix(multivar): correct typo in multivar.tex

### DIFF
--- a/tex/diffgeo/multivar.tex
+++ b/tex/diffgeo/multivar.tex
@@ -159,7 +159,7 @@ You might notice there are \emph{two} upgrades happening here:
 	\ii The codomain got upgraded from $\RR$ to $\RR^m$.
 \end{itemize}
 
-The point of this section is that the second upgrade is
+The point of this section is that the second upgrade
 is \emph{super easy} in comparison to the first upgrade,
 and basically doesn't require doing anything new.
 All the interesting actions happens because we upgraded the domain, not the codomain.


### PR DESCRIPTION
changed " The point of this section is that the second upgrade is is \emph{super easy}" to " The point of this section is that the second upgrade is \emph{super easy}"