### PR TITLE
fix: Corrected two typos and suggested one chili

### DIFF
--- a/tex/H113/action.tex
+++ b/tex/H113/action.tex
@@ -349,6 +349,7 @@ A trivial result that gets used enough that I should explicitly call it out:
 
 \begin{problem}
 	[Athemath Community-Building Event \#1, Fall 2022]
+	\onechili
 	A group action $\cdot$ of a group $G$ on set $X$ is said to be
 	\begin{itemize}
 		\ii \vocab{transitive} if for all $x_1, x_2 \in X$,

--- a/tex/H113/grp-intro.tex
+++ b/tex/H113/grp-intro.tex
@@ -683,9 +683,8 @@ By requiring an inverse element to exist, you get rid of this issue.
 it's hard to define inverses without it.)
 
 Even more abstruse comment:
-\Cref{thm:cayley_theorem} shows that groups are actually shadows of
-the so-called symmetric groups (defined later, also called permutation groups).
-This makes rigorous the notion that ``groups are very symmetric''.
+\Cref{thm:cayley_theorem} shows that groups are actually shadows of symmetric
+groups. This makes rigorous the notion that ``groups are very symmetric''.
 
 \section{\problemhead}
 

--- a/tex/H113/ring-flavors.tex
+++ b/tex/H113/ring-flavors.tex
@@ -485,10 +485,10 @@ We call a function $\Norm \colon R \to \ZZ_{\geq 0}$ that satisfies the two cond
 	See \Cref{sec:norms_traces} for the explanation why this norm is the natural one.}
 	will be:
 	\[
-		\Norm_{\QQ(\sqrt{11})/\QQ}(a + b \sqrt 11) = (a + b \sqrt 11) (a - b \sqrt 11)
+		\Norm_{\QQ(\sqrt{11})/\QQ}(a + b \sqrt{11}) = (a + b \sqrt{11}) (a - b \sqrt{11})
 		= a^2 - 11 b^2.
 	\]
-	Since we need a Euclidean norm, we will take $\Norm(a + b \sqrt 11) = |a^2 - 11 b^2|.$
+	Since we need a Euclidean norm, we will take $\Norm(a + b \sqrt{11}) = |a^2 - 11 b^2|.$
 
 	Given two elements $a$ and $b$ in $\ZZ[\sqrt{11}]$ with $b \neq 0$,
 	we will try to compute $r$ such that $\Norm(r) < \Norm(b)$ as $r = a - q b$ as before.


### PR DESCRIPTION
1.  [fix(grp-intro) Delete an already resolved TODO-ish sentance](https://github.com/vEnhance/napkin/commit/48ff4dcc7349da8ccabb83fe65a246c19d15083c)

    Symmetric groups were already defined earlier in Example 1.1.13, so I removed this expression.

2.  [fix(ring-flavors): Typo, use \sqrt{11} instead of \sqrt 11](https://github.com/vEnhance/napkin/commit/51d119f5a4470e2bfa839f0c1d94e84b1a3b7cad)

    | Before | ![](https://github.com/user-attachments/assets/e30cf14b-532a-43fe-a79b-1eed6bc02d3c) |
    |------:|-------|
    | After | ![](https://github.com/user-attachments/assets/b776b145-367f-4819-a0b5-13e0e52f7b50) |

3.  [fix(action): Add a chili to 16F](https://github.com/vEnhance/napkin/commit/5f6d1ffbb2c342b79856ff1fe3838cb88cdf67c0)

    I personally find 16F significantly harder than 16C, even though 16C has a chili mark. If we're not going to remove the chili from 16C, it would make sense to *add* one to 16F as well. If there's an easier solution that I might have missed, please let me know!