### PR TITLE
fix(topology): Fix typo of Problem 6C

### DIFF
--- a/tex/topology/metric-prop.tex
+++ b/tex/topology/metric-prop.tex
@@ -414,7 +414,7 @@ i.e.\ the only examples look quite like the one we've given above.
 	Let $M$ be a metric space.
 	Construct a complete metric space $\ol M$
 	such that $M$ is a subspace of $\ol M$,
-	and every open set of $\ol M$ contains a point of $M$
+	and every non-empty open set of $\ol M$ contains a point of $M$
 	(meaning $M$ is \vocab{dense} in $\ol M$).
 	\begin{hint}
 		As a set, we let $\ol M$ be the set of Cauchy


### PR DESCRIPTION
The empty set serves as a counterexample to this problem. If we revise the wording like this, the problem becomes properly well-posed.