### PR TITLE
fix(topology): subspace -> subset

### DIFF
--- a/tex/topology/constructions.tex
+++ b/tex/topology/constructions.tex
@@ -124,7 +124,7 @@ So in this notation, \[ D^n / S^{n-1} = S^n. \]
 
 \begin{example}[Weirder quotient spaces]
 	\label{ex:quotient_by_open_set}
-	If the subspace $A$ is not closed in $X$, $X/A$ would be quite weird.
+	If the subset $A$ is not closed in $X$, $X/A$ would be quite weird.
 
 	For instance, let $X = \RR$ and $A = (0, 1)$. Then the space $X/A$ consists of the points
 	$(-\infty, 0] \cup \{A/A\} \cup [1, \infty)$.


### PR DESCRIPTION
For a quotient space $X/A$, it's enough that $A$ is a subset of $X$. $A$ doesn't have to be a topological space in its own right.