### PR TITLE
fix(topology): Add parentheses to add some clarity

### DIFF
--- a/tex/topology/constructions.tex
+++ b/tex/topology/constructions.tex
@@ -361,7 +361,7 @@ We say that $X$ is \vocab{finite} if only finitely many cells were used.
 	we take its boundary $S^{k-1}_\alpha$ and weld it onto
 	$X^{k-1}$ via an \vocab{attaching map} $S^{k-1}_\alpha \to X^{k-1}$.
 	Then
-	\[ X^k = X^{k-1} \amalg \left(\coprod_\alpha e^k_\alpha\right) / {\sim} \]
+	\[ X^k = \left( X^{k-1} \amalg \left(\coprod_\alpha e^k_\alpha\right) \right) / {\sim} \]
 	where $\sim$ identifies each boundary point of $e^k_\alpha$
 	with its image in $X^{k-1}$.
 \end{definition}


### PR DESCRIPTION
I felt the original formula was a bit ambiguous, so I added parentheses to make it clearer.  
What do you think?

Before:

<img width="1671" alt="image" src="https://github.com/user-attachments/assets/dfccdf66-cfd8-4c22-90c3-7f015a1b5b48" />

After:

<img width="1622" alt="image" src="https://github.com/user-attachments/assets/242addd5-2319-448d-ab6c-23bad52b267e" />
