### PR TITLE
fix: typo in dets.tex ("and" not "an")

### DIFF
--- a/tex/linalg/dets.tex
+++ b/tex/linalg/dets.tex
@@ -274,7 +274,7 @@ without any reference to matrices.
 In this way, we also get \[ \det(S \circ T) = \det(S) \det(T) \] for free.
 
 More generally if we replace $2$ by $n$,
-an write out the result of expanding
+and write out the result of expanding
 \[ \left( a_{11}e_1 + a_{21}e_2 + \cdots \right) \wedge \dots \wedge
 	\left( a_{1n}e_1 + a_{2n}e_2 + \dots + a_{nn} e_n \right) \]
 then you will get the formula


### PR DESCRIPTION
As suggested in the title.

(Also, is the following duplicate of $T \colon V \to V$ intentional?)

https://github.com/vEnhance/napkin/blob/e5eb4305bda23f0b363a0e0c182e33e873b3d86f/tex/linalg/dets.tex#L337-L342