### PR TITLE
fix: proofread Frontmatter (preface grammar)

### DIFF
--- a/tex/frontmatter/preface.tex
+++ b/tex/frontmatter/preface.tex
@@ -44,7 +44,7 @@ particularly in assorted challenge problems which are
 taken from mathematical competitions.
 However, in general I think this would be a good reference
 for anyone with some amount of mathematical maturity and curiosity.
-Examples include but certainly not limited to:
+Examples include but are certainly not limited to:
 math undergraduate majors, physics/CS majors,
 math PhD students who want to hear a little bit
 about fields other than their own,


### PR DESCRIPTION
## Summary

Proofreading pass over the **Frontmatter** part (issue #315), covering the files included before `\mainmatter` in `Napkin.tex`:

- `tex/frontmatter/title-embellishments.tex`
- `tex/frontmatter/preface.tex`
- `tex/frontmatter/advice.tex` (and the `tex/frontmatter/digraph.tex` dependency chart it inputs)

## Changes

- **`tex/frontmatter/preface.tex`**: Added a missing "are" in the list of intended audiences. The sentence read "Examples include but certainly not limited to:", which is now corrected to "Examples include but are certainly not limited to:".

## Notes

The remaining frontmatter prose read cleanly — no other typos, grammatical issues, or errors were found. (`salespitch.tex` is part of the "Starting Out" part, not Frontmatter, so it is out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKE8Fts54xiam2pLMa57GX)_