### PR TITLE
fix: proofread Starting Out part

### DIFF
--- a/tex/frontmatter/salespitch.tex
+++ b/tex/frontmatter/salespitch.tex
@@ -53,7 +53,7 @@ learning more about spaces.
 We'll find out that ``metric spaces'' are actually too specific,
 and that it's better to work with \buzzword{topological spaces},
 which are based on the so-called \buzzword{open sets}.
-You'll then get to see the buddings of some geometrical ideals,
+You'll then get to see the buddings of some geometrical ideas,
 ending with the really great notion of \buzzword{compactness},
 a powerful notion that makes real analysis tick.
 
@@ -190,7 +190,7 @@ us a way to evaluate real integrals that can't be evaluated otherwise.)
 \pitch{part:measure}
 Measure theory is the upgraded version of integration.
 The Riemann integration is for a lot of purposes not really sufficient;
-for example, if $f$ is the function equals $1$ at rational numbers
+for example, if $f$ is the function equal to $1$ at rational numbers
 but $0$ at irrational numbers,
 we would hope that $\int_0^1 f(x) \; dx = 0$,
 but the Riemann integral is not capable of handling this function $f$.
@@ -222,7 +222,7 @@ in ways that make them both easy to state and straightforward to prove.
 Multivariable calculus is often confusing
 because of all the partial derivatives.
 But we'll find out that, armed with our good understanding
-of linear algebra, that we're really looking at a \buzzword{total derivative}:
+of linear algebra, we're really looking at a \buzzword{total derivative}:
 at every point of a function $f \colon \RR^n \to \RR$
 we can associate a \emph{linear map} $Df$ which
 captures in one object the notion of partial derivatives.

--- a/tex/frontmatter/salespitch.tex
+++ b/tex/frontmatter/salespitch.tex
@@ -281,8 +281,7 @@ tell you about ways to cover $X$ with a so-called
 \buzzword{covering projection}.
 One picture is that one can wrap a real line $\RR$ into a helix shape
 and then project it down into the circle $S^1$.
-This will turn out to correspond to the fact that $\pi_1(S^1) = \ZZ$
-which has only one subgroup.
+This will turn out to correspond to the fact that $\pi_1(S^1) = \ZZ$.
 More generally the subgroups of $\pi_1(X)$ will be in
 bijection with ways to cover the space $X$!
 

--- a/tex/topology/metric-top.tex
+++ b/tex/topology/metric-top.tex
@@ -398,7 +398,7 @@ with the homeomorphism being just the identity map.
 \begin{example}[$\RR^2$]
 	If $M = N = \RR$, we get $\RR^2$, the Euclidean plane.
 	The metric $d_{\text{Euclid}}$ is the one we started with,
-	but using either of the other two metric works fine as well.
+	but using either of the other two metrics works fine as well.
 \end{example}
 
 The product metric plays well with convergence of sequences.
@@ -817,7 +817,7 @@ The reason for the opposing terms is the following theorem:
 		Projecting these missing intervals to the $y$-axis you find uncountably
 		many intervals (one for each $x \in [0,1]$) all of which are disjoint.
 		In particular, summing the $\eps_x$ you get that a sum of uncountably
-		many positive reals is $1$.
+		many positive reals is at most $1$.
 
 		But in general it isn't possible for an uncountable family $\mathcal F$
 		of positive reals to have finite sum.


### PR DESCRIPTION
## Proofreading: Starting Out

Part of the proofreading campaign (#315). This covers the **Starting Out** part, i.e.\ the files included under `\part{Starting Out}` in `Napkin.tex`:

- `tex/frontmatter/salespitch.tex`
- `tex/H113/grp-intro.tex`
- `tex/topology/metric-top.tex`

### Fixes applied
- **salespitch** (basic topology pitch): `geometrical ideals` → `geometrical ideas` (topology has no "ideals").
- **salespitch** (measure theory pitch): `the function equals 1 at rational numbers` → `the function equal to 1 ...` (grammar).
- **salespitch** (differential geometry pitch): removed a duplicated `that` ("find out that, ..., that we're really looking at").
- **salespitch** (algebraic topology pitch): removed the incorrect clause `which has only one subgroup` from `$\pi_1(S^1) = \mathbb{Z}$`. $\mathbb{Z}$ has infinitely many subgroups ($n\mathbb{Z}$), and the clause also contradicted the following sentence stating that subgroups of $\pi_1(X)$ correspond to covers of $X$.
- **metric-top** (product metric example): `either of the other two metric works` → `metrics`.
- **metric-top** (strictly-increasing function problem solution): the disjoint gaps live inside `[0,1]`, so their total length is **at most** `1`, not exactly `1`. Changed `is 1` → `is at most 1`. (The argument only needs finiteness, so this is cosmetic but more correct.)

The numerics in `grp-intro.tex` (primitive-root tables, the $D_{10}$ Asymptote figure, group-order lists) and the proofs in `metric-top.tex` all checked out otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)