### PR TITLE
fix: proofread Basic Topology part

### DIFF
--- a/tex/topology/compactness.tex
+++ b/tex/topology/compactness.tex
@@ -620,7 +620,7 @@ Of these \Cref{thm:bzw} is definitely my favorite.
 		\[ 0 < r_i < \frac{1}{2} \min_{j \neq i} d(a_i, a_j) \]
 		Define $C_i$ as an open ball at $a_i$ with radius $r_i$.
 		Note that every ball is disjoint.
-		Then, we define $F$ as follows
+		Then, we define $F$ by
 		\[
 			F(x) = \begin{cases}
 				0 & x \not\in C_i \\

--- a/tex/topology/compactness.tex
+++ b/tex/topology/compactness.tex
@@ -608,7 +608,7 @@ Of these \Cref{thm:bzw} is definitely my favorite.
 		We show the contrapositive:
 		if $M$ is not compact, then there exists a homeomorphic unbounded metric.
 
-		The main step is to construction
+		The main step is to construct
 		an unbounded continuous function $F \colon M \to \RR$.
 		Once such a function $F$ is defined, the metric
 		\[ d'(x, y) \coloneqq d(x, y) + \abs{F(x) - F(y)} \]
@@ -617,14 +617,14 @@ Of these \Cref{thm:bzw} is definitely my favorite.
 		So, let $a_1$, $a_2$, \dots\ be a sequence in $M$
 		with no convergent subsequence.
 		For each $a_i$, there exists a radius $r_i$ such that
-		\[ 0 < r_i < \frac{1}{2} \min_{j} d(a_i, a_j) \]
+		\[ 0 < r_i < \frac{1}{2} \min_{j \neq i} d(a_i, a_j) \]
 		Define $C_i$ as an open ball at $a_i$ with radius $r_i$.
 		Note that every ball is disjoint.
-		Then, we define $F$ as follow
+		Then, we define $F$ as follows
 		\[
 			F(x) = \begin{cases}
 				0 & x \not\in C_i \\
-				\frac{i}{r_1}(r_i - d(x, a_i)) & x \in C_i
+				\frac{i}{r_i}(r_i - d(x, a_i)) & x \in C_i
 			\end{cases}
 		\]
 		which can be seen to be continuous.
@@ -662,7 +662,7 @@ Of these \Cref{thm:bzw} is definitely my favorite.
 		If we repeat in this way,
 		we get a nested sequence $K_0 \supseteq K_1 \supseteq \dots$
 		and the radii of $C_i$ approach zero
-		(since each is at most half the previous once).
+		(since each is at most half the previous one).
 		Thus some point $p$ lies in $\bigcap_n K_n$ which is impossible.
 
 		Now for part (b),
@@ -709,7 +709,7 @@ Of these \Cref{thm:bzw} is definitely my favorite.
 		\ii Now suppose there are neon yellow points.
 		We claim there is a neon yellow circle minimal by inclusion.
 		If not, then repeat the argument of (a) to get a contradiction,
-		since any neon yellow circle must have diameter the distance from $p$ to $q$.
+		since any neon yellow circle must have diameter at least the distance from $p$ to $q$.
 		So we can find a neon yellow circle $\mathscr C$ whose
 		interior is all magenta and cyan.
 		Now repeat the argument of the previous part,

--- a/tex/topology/metric-prop.tex
+++ b/tex/topology/metric-prop.tex
@@ -345,7 +345,7 @@ i.e.\ the only examples look quite like the one we've given above.
 			&\vdotswithin< \\
 		\end{align*}
 		and so for large $M < N$ we have
-		\[ d(x_M, x_N) < \left( r^M + r^{M+1} + \dots + r^N \right) \cdot c
+		\[ d(x_M, x_N) < \left( r^M + r^{M+1} + \dots + r^{N-1} \right) \cdot c
 			< \frac{r^M}{1-r} \cdot c
 		\]
 		which tends to zero once $M$ is large enough.

--- a/tex/topology/top-more.tex
+++ b/tex/topology/top-more.tex
@@ -638,8 +638,8 @@ ever have to worry too much about are the $r$-neighborhoods.
 		Part (a) is straightforward:
 		assume for contradiction that the connected component of $p$ is
 		a disjoint union $U \sqcup V$ of two nonempty sets open in $X$.
-		WLOG, assume $x \in U$
-		Let $S$ be one of the subspaces containing $X$ that intersects $V$.
+		WLOG, assume $p \in U$.
+		Let $S$ be one of the subspaces containing $p$ that intersects $V$.
 		Then $S = (S \cap U) \sqcup (S \cap V)$ rewrites $S$ as the disjoint union
 		of two sets which are open in $S$, contradicting the connectedness of $S$.
 


### PR DESCRIPTION
Proofreading pass over the **Basic Topology** part (issue #315), covering `tex/topology/metric-prop.tex`, `tex/topology/top-more.tex`, and `tex/topology/compactness.tex`.

All findings were minor (typos and small slips in worked solutions); no large mathematical errors were found.

### `metric-prop.tex`
- **Banach fixed point theorem solution:** off-by-one in the geometric sum. The bound on $d(x_M, x_N)$ telescopes as $d(x_M,x_{M+1}) + \dots + d(x_{N-1},x_N)$, so the sum should run to $r^{N-1}$, not $r^N$.

### `top-more.tex`
- **Connected-component solution (Problem on connected components):** the connected component is of the point $p$, but the solution wrote `$x \in U$` (should be `$p \in U$`) and "subspaces containing $X$" (should be "containing $p$"). Also restored a dropped sentence-ending period.

### `compactness.tex` (final problem, Royce Yao's solution)
- The radius bound `$0 < r_i < \tfrac12 \min_j d(a_i,a_j)$` must exclude $j=i$; otherwise the minimum is $d(a_i,a_i)=0$ and the inequality is unsatisfiable. Changed to `\min_{j \neq i}`.
- The tent function used `$\frac{i}{r_1}$`, giving peak value $i\,r_i/r_1$, which need not be unbounded since $r_i$ can shrink. Using `$\frac{i}{r_i}$` makes the peak $F(a_i) = i$, which is the unboundedness the proof relies on. (Both forms are continuous since they vanish on the ball boundary.)
- Typos: "to construction" → "to construct", "as follow" → "as follows".
- In the circles-partition problem: "half the previous once" → "half the previous one".
- Clarified that a neon-yellow circle "must have diameter **at least** the distance from $p$ to $q$" (this lower bound is what prevents the radii from shrinking to zero).

Part of the proofreading campaign tracked in #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019UwxuF3uvtsRZGNbKqFrxe)_