### PR TITLE
fix: proofread Linear Algebra part

### DIFF
--- a/tex/linalg/dets.tex
+++ b/tex/linalg/dets.tex
@@ -666,7 +666,7 @@ then the theorem is almost obvious:
 			\sum_{\substack{\sigma \in S_m \\ \sigma \text{ fixes } (i_k)}}
 			\left( \sign(\sigma)
 			\cdot \prod_{i \notin (i_k)} -x_{i \sigma(i)}
-			\prod_{i \in (i_k)}^n \left( a \cdot - x_{ii}
+			\prod_{i \in (i_k)} \left( a - x_{ii}
 			\right)\right) \\
 			% -----------------------
 			&=
@@ -738,7 +738,7 @@ then the theorem is almost obvious:
 			&= \sum_{1 \le i_1 < \dots < i_n \le m}
 			\sum_{\pi \in S_n} \sign(\pi) \prod_{k=1}^n x_{i_{\pi(k)}k} \\
 			&= \sum_{\substack{X \subseteq \{1,\dots,m\} \\ \left\lvert X \right\rvert = n}}
-			\sum_{\pi \in S_X} \sign(\pi) \prod_{i \in X} x_{t \pi(t)}
+			\sum_{\pi \in S_X} \sign(\pi) \prod_{t \in X} x_{t \pi(t)}
 		\end{align*}
 		Hence it remains to show that the permutations over $X$
 		are in bijection with the permutations over $S_m$ which fix $\{1, \dots, m\} - X$,

--- a/tex/linalg/fourier.tex
+++ b/tex/linalg/fourier.tex
@@ -328,7 +328,7 @@ In that sense, we could rewrite the above table as:
 			& S \subseteq \left\{ 1, \dots, n \right\}
 			& \prod_{s \in S} x_s \\
 		\text{Finite group} & Z
-			& \xi \in \wh Z \cong Z & e( i \xi \cdot x) \\
+			& \xi \in \wh Z \cong Z & e(\xi \cdot x) \\
 		\text{Fourier series} & \TT \cong [-\pi, \pi]  & n \in \ZZ
 			& \exp(inx) \\
 		\text{Discrete} & \ZZ/n\ZZ & \xi \in \ZZ/n\ZZ
@@ -609,15 +609,15 @@ that $f(+1, \dots, +1) = +1$ (hence possibility of anti-dictatorship).
 	\[
 		\EE D(f(x_\bullet), g(y_\bullet), h(z_\bullet))
 		=
-		\left( \wh f(S) \wh g(T) + \wh g(S) \wh h(T) + \wh h(S) \wh f(T) \right)
+		\sum_S \left( \wh f(S) \wh g(S) + \wh g(S) \wh h(S) + \wh h(S) \wh f(S) \right)
 		\left( -\frac13 \right)^{|S|}.
 	\]
 	Then, we obtain that
 	\begin{align*}
 		&\EE \frac14 \left( 1 + D(f(x_\bullet), g(y_\bullet), h(z_\bullet)) \right) \\
 		=& \frac14 + \frac14\sum_S
-		\left( \wh f(S) \wh g(T) + \wh g(S) \wh h(T) + \wh h(S) \wh f(T) \right)
-		\wh f(S)^2 \left( -\frac13 \right)^{|S|}.
+		\left( \wh f(S) \wh g(S) + \wh g(S) \wh h(S) + \wh h(S) \wh f(S) \right)
+		\left( -\frac13 \right)^{|S|}.
 	\end{align*}
 	Comparing this with the definition of $D$ gives the desired result.
 	\end{sol}

--- a/tex/linalg/inner-form.tex
+++ b/tex/linalg/inner-form.tex
@@ -303,7 +303,7 @@ this implies independence:
 	for $a_i$ in $\RR$ or $\CC$.
 	Then \[ 0 = \left< v_1, \sum a_i v_i \right> = \ol{a_1} \norm{v_1}^2. \]
 	Hence $a_1 = 0$, since we assumed $\norm{v_1} \neq 0$.
-	Similarly $a_2 = \dots = a_m = 0$.
+	Similarly $a_2 = \dots = a_n = 0$.
 \end{proof}
 
 In light of this, we can now consider a stronger condition on our bases:
@@ -398,7 +398,7 @@ Then consider the sequence
 	Since $\RR$ is complete, $s_n$ is Cauchy
 	if and only if it converges.
 	Since $s_n$ consists of nonnegative real numbers,
-	converges holds if and only if $s_n$ is bounded,
+	convergence holds if and only if $s_n$ is bounded,
 	or equivalently if $\sum \left\lvert c_i \right\rvert^2 < \infty$.
 \end{proof}
 

--- a/tex/linalg/transpose.tex
+++ b/tex/linalg/transpose.tex
@@ -146,7 +146,7 @@ We proceed to give a bogus proof of this result.
 	Then, from the definition of $T^\vee \colon W^\vee \to V^\vee$ we can see
 	\begin{align*}
 		T^\vee(f_1^\vee) &= e_1^\vee, \; \dots, \; T^\vee(f_k^\vee) = e_k^\vee \\
-		T^\vee(f_{k+1}^\vee) &= \dots = T(f_m^\vee) = 0.
+		T^\vee(f_{k+1}^\vee) &= \dots = T^\vee(f_m^\vee) = 0.
 	\end{align*}
 	We can then combine this with our (non-canonical) isomorphism $W \to W^\vee$
 	to get that $M^\top M$ is the matrix for the composed map $V \to V^\vee$ by
@@ -348,7 +348,7 @@ we need the basis to be orthonormal to proceed.
 	If we write $T$ as a matrix in this basis,
 	then the matrix $T^\dagger$ (in the same basis)
 	is the \emph{conjugate transpose} of the matrix of $T$;
-	that is, the $(i,j)$th entry of $T^\vee$
+	that is, the $(i,j)$th entry of $T^\dagger$
 	is the complex conjugate of the $(j,i)$th entry of $T$.
 \end{theorem}
 \begin{proof}

--- a/tex/linalg/vector-space.tex
+++ b/tex/linalg/vector-space.tex
@@ -1298,9 +1298,9 @@ for many of these problems.
 	\begin{sol}
 		Consider
 		\[
-			\{0\} \subsetneq \ker S \subseteq \ker S^2 \subseteq \ker S^3 \subseteq \dots
+			\{0\} \subsetneq \ker T \subseteq \ker T^2 \subseteq \ker T^3 \subseteq \dots
 			\text{  and  }
-			V \supsetneq \img S \supseteq \img S^2 \supseteq \img S^3 \supseteq \dots.
+			V \supsetneq \img T \supseteq \img T^2 \supseteq \img T^3 \supseteq \dots.
 		\]
 		For dimension reasons, these subspaces must eventually stabilize:
 		for some large integer $N$,
@@ -1309,7 +1309,7 @@ for many of these problems.
 		When this happens, $\ker T^N \bigcap \img T^N = \{0\}$,
 		since $T^N$ is an automorphism of $\img T^N$.
 		On the other hand, by Rank-Nullity we also have
-		$\dim \ker T^N + \dim \img T^n = \dim V$.
+		$\dim \ker T^N + \dim \img T^N = \dim V$.
 		Thus for dimension reasons, $V = \ker T^N \oplus \img T^N$.
 	\end{sol}
 \end{sproblem}


### PR DESCRIPTION
Proofreading pass over the **Linear Algebra** part (issue #315), covering `vector-space`, `eigenvalues`, `dual-trace`, `dets`, `inner-form`, `fourier`, and `transpose`. All findings were minor (typos / index slips); no large mathematical errors were found.

### Fixes

**`vector-space.tex`**
- In the solution to the "eventual image/kernel splitting" problem, the chain of subspaces was written with `S` (`\ker S`, `\img S`) but the problem and rest of the solution use `T`. Changed `S` → `T`.
- Rank-nullity step wrote `\dim \img T^n` with a lowercase `n`; should be `T^N` to match the rest of the argument.

**`inner-form.tex`**
- Orthogonal-vectors-are-independent proof concluded `a_2 = \dots = a_m = 0`, but the vectors are `v_1, …, v_n`; changed `a_m` → `a_n`.
- "converges holds if and only if" → "convergence holds if and only if".

**`fourier.tex`**
- Pontryagin-duality teaser table listed the finite-group characters as `e(i ξ·x)`; the extra `i` is spurious (and inconsistent with the row above and with `e(θ)=exp(2πiθ)`). Changed to `e(ξ·x)`.
- Arrow's theorem lemma solution: the last two display lines dropped the `∑_S`, kept a free index `T` (instead of `S` after collapsing the `S=T` case), and carried a spurious `\hat f(S)^2` factor. Corrected so the derivation matches the formula it is proving.

**`transpose.tex`**
- Bogus-proof display wrote `T(f_m^∨)` where it should read `T^∨(f_m^∨)`.
- "Adjoints are conjugate transposes" theorem referred to "the (i,j)th entry of `T^∨`"; should be `T^†` (the theorem is about the adjoint).

**`dets.tex`** (inside optional `\twochili` problem solutions)
- Removed a double operator `a \cdot - x_{ii}` → `a - x_{ii}` (and a stray product superscript).
- Fixed a free index: `\prod_{i \in X} x_{t\pi(t)}` → `\prod_{t \in X} x_{t\pi(t)}`.

Part of the proofreading campaign tracked in #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuoHDxiTrBWwPbVsQ8oNCE)_