### PR TITLE
fix: proofread More on Groups part

### DIFF
--- a/tex/H113/action.tex
+++ b/tex/H113/action.tex
@@ -335,9 +335,9 @@ A trivial result that gets used enough that I should explicitly call it out:
     \begin{hint}
         Let $H$ act on the left cosets $\{gH \mid g \in G\}$
         by left multiplication: $h \cdot gH = hgH$.
-        Consider any orbit $\OO$
+        Consider any orbit $\OO$.
         By the orbit-stabilizer theorem, $\left\lvert \OO \right\rvert$
-        divides $\left\lvert H \right\rvert$ which divides $n$, so $\OO$
+        divides $\left\lvert H \right\rvert$ which divides $n$, so $\left\lvert \OO \right\rvert$
         divides $n$. But $\left\lvert \OO \right\rvert \le p$ since
         there are $p$ cosets. So either $\OO = \{H\}$ or $\OO$ contains
         all cosets. Show that the latter is impossible and conclude.

--- a/tex/H113/structure.tex
+++ b/tex/H113/structure.tex
@@ -338,8 +338,8 @@ intrinsic to the module $M$.
 	This means, as $R/(p)$-vector space,
 	\[ \dim \pi(M) = \dim \pi(R/(p^{e_1})) + \dim \pi(R/(p^{e_2})) + \cdots + \dim \pi(R/(p^{e_m})). \]
 
-	Note that, for each term $R/(p^{e_1})$, then
-	\[ \dim p^e (R/(p^{e_i})) / p^{e+1} (R/(p^{e_1})) = \begin{cases}
+	Note that, for each term $R/(p^{e_i})$, then
+	\[ \dim p^e (R/(p^{e_i})) / p^{e+1} (R/(p^{e_i})) = \begin{cases}
 		1 & e < e_i \\
 		0 & \text{otherwise}.
 	\end{cases} \]
@@ -576,7 +576,7 @@ the PID condition more or less lets you perform a Euclidean algorithm.
 	\end{subproof}
 	Let $s_1 = (a_{ij})_{i,j}$ be the GCD of all entries.
 	Now by repeatedly applying this algorithm,
-	we can cause $s$ to appear in the upper left hand corner.
+	we can cause $s_1$ to appear in the upper left hand corner.
 	Then, we use it to kill off all the entries in the first
 	row and the first column, thus arriving at a matrix
 	\[ \begin{bmatrix}

--- a/tex/H113/sylow.tex
+++ b/tex/H113/sylow.tex
@@ -310,7 +310,7 @@ Math is weird.
 
 		But consider the Sylow $2$-subgroups.
 		These have $8$ elements each, and we conclude therefore
-		that there is at exactly one Sylow $2$-subgroup.
+		that there is exactly one Sylow $2$-subgroup.
 		That subgroup is normal, contradiction.
 	\end{sol}
 \end{problem}


### PR DESCRIPTION
Proofreading of the **More on Groups** part (issue #315), covering the chapters:

- `tex/H113/action.tex` (Group actions overkill AIME problems)
- `tex/H113/sylow.tex` (Find all groups)
- `tex/H113/structure.tex` (The PID structure theorem)

## Fixes

All issues found were minor (typos / notation slips):

- **`action.tex`** — In the hint for the "subgroup of smallest-prime index is normal" problem: added a missing period after "Consider any orbit $\mathcal O$", and restored the missing cardinality bars in "so $\mathcal O$ divides $n$" → "so $|\mathcal O|$ divides $n$".
- **`sylow.tex`** — In the solution showing no simple group of order 56 exists: "there is at exactly one Sylow $2$-subgroup" → "there is exactly one Sylow $2$-subgroup".
- **`structure.tex`** — In the primary-form uniqueness proof, fixed an index mismatch in the dimension formula: "$R/(p^{e_1})$" → "$R/(p^{e_i})$" (the summand index should be $i$, not $1$; the surrounding numerator already used $e_i$). Also in the Smith normal form proof, "$s$" → "$s_1$" to match the variable defined just above.

I verified the worked computations along the way (the AIME/Burnside count of $300$, the triple-product-of-primes element count, the Smith normal form Euclidean-algorithm example, and the $\mathbb{Z}/9 \oplus \mathbb{Z}/3^5$ quotient-dimension example); all check out. No large mathematical errors were found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016HZdCN5NoxqtbdrD3gZeGi)_