### PR TITLE
fix: proofread Representation Theory part

### DIFF
--- a/tex/rep-theory/applications.tex
+++ b/tex/rep-theory/applications.tex
@@ -58,7 +58,7 @@ First, we prove:
 	To see this, note that $T_i$ commutes with elements of $G$,
 	and hence is an intertwining operator $T_i \colon V \to V$.
 	Thus by Schur's lemma, $T_i = \lambda_i \cdot \id_V$
-	and $\Tr T = \lambda_i \dim V$.
+	and $\Tr T_i = \lambda_i \dim V$.
 	By \Cref{lem:group_ring_integral}, $\lambda_i \in \ol\ZZ$, as desired.
 
 	Now we are done, since $\ol{\chi_V(C_i)} \in \ol\ZZ$ too
@@ -83,7 +83,7 @@ In what follows $p$ and $q$ will always denote prime numbers.
 
 \begin{lemma}[On $\gcd(|C|, \dim V) = 1$]
 	\label{lem:burnside_ant_lemma}
-	Let $V = (V, \rho)$ be an complex irrep of $G$.
+	Let $V = (V, \rho)$ be a complex irrep of $G$.
 	Assume $C$ is a conjugacy class of $G$ with $\gcd(|C|, \dim V) = 1$.
 	Then for any $g \in C$, either
 	\begin{itemize}
@@ -112,7 +112,7 @@ In what follows $p$ and $q$ will always denote prime numbers.
 	By contradiction.
 	Assume $C$ is such a conjugacy class, and fix any $g \in C$.
 	By the second orthogonality formula (\Cref{prob:second_orthog})
-	applied $g$ and $1_G$ (which are not conjugate since $g \neq 1_G$) we have
+	applied to $g$ and $1_G$ (which are not conjugate since $g \neq 1_G$) we have
 	\[ \sum_{i=1}^r \dim V_i \chi_{V_i}(g) = 0 \]
 	where $V_i$ are as usual all irreps of $G$.
 	\begin{exercise}
@@ -128,7 +128,7 @@ In what follows $p$ and $q$ will always denote prime numbers.
 	We claim this is a nontrivial normal subgroup of $G$.
 	It is easy to check $H$ is normal,
 	and since $|C| > 1$ we have that $H$ is nontrivial.
-	As represented by $V$ each element of $H$ acts trivially in $G$,
+	As represented by $V$ each element of $H$ acts trivially on $V$,
 	so since $V$ is nontrivial and irreducible, $H \neq G$.
 	This contradicts the assumption that $G$ was simple.
 \end{proof}

--- a/tex/rep-theory/characters.tex
+++ b/tex/rep-theory/characters.tex
@@ -3,7 +3,7 @@
 Characters are basically the best thing ever.
 To every representation $V$ of $A$ we will attach a
 so-called character $\chi_V \colon A \to k$.
-It will turn out that the characters of finite-dimensional irreps of $V$
+It will turn out that the characters of finite-dimensional irreps of $A$
 will determine the representation $V$ completely.
 Thus a finite-dimensional irrep is just specified by a set of $\dim A$ numbers.
 
@@ -11,7 +11,7 @@ Thus a finite-dimensional irrep is just specified by a set of $\dim A$ numbers.
 \begin{definition}
 	Let $V = (V, \rho)$ be a finite-dimensional representation of $A$.
 	The \vocab{character} $\chi_V \colon A \to k$ attached to
-	$A$ is defined by $\chi_V = \Tr \circ \rho$, i.e.\
+	$V$ is defined by $\chi_V = \Tr \circ \rho$, i.e.\
 	\[ \chi_V(a) \defeq \Tr\left( \rho(a) \colon V \to V \right). \]
 \end{definition}
 Since $\Tr$ and $\rho$ are additive, this is a $k$-linear map
@@ -91,7 +91,7 @@ Thus $[A,A]$ is contained in the kernel of each $\chi_V$.
 	\begin{enumerate}[(a)]
 		\ii If $A$ is commutative, then $[A,A] = \{0\}$
 		and $A\ab = A$.
-		\ii If $A = \Mat_k(d)$, then $[A,A]$ consists exactly
+		\ii If $A = \Mat_d(k)$, then $[A,A]$ consists exactly
 		of the $d \times d$ matrices of trace zero.
 		(Proof: harmless exercise.)
 		Consequently, $A\ab$ is one-dimensional.

--- a/tex/rep-theory/semisimple.tex
+++ b/tex/rep-theory/semisimple.tex
@@ -80,12 +80,12 @@ by the $mn$ choices of compositions
 \end{tikzcd}
 \end{center}
 where the first arrow is inclusion to the $i$th component of $V^{\oplus m}$
-(for $1 \le i \le m$) and the second arrow is inclusion to the $j$th
+(for $1 \le i \le m$) and the second arrow is projection onto the $j$th
 component of $V^{\oplus n}$ (for $1 \le j \le n$).
 However, by Schur's lemma on each of these compositions,
 we know they must be constant.
 
-Thus, $\Homrep(V^{\oplus n}, V^{\oplus m})$ consist of $n \times m$ ``matrices''
+Thus, $\Homrep(V^{\oplus n}, V^{\oplus m})$ consists of $m \times n$ ``matrices''
 of constants, and the map is provided by
 \[
 	\begin{bmatrix}
@@ -129,11 +129,11 @@ More generally, we have:
 \begin{proof}
 	Apply Schur's lemma to the inclusion $W \injto V$.
 \end{proof}
-Recall from \Cref{sec:vector_space_linear_maps} that a linear maps from a
-$n$-dimensional vector space to a $m$-dimensional vector space can be written as
-a $n \times m$ matrix. Here the situation is similar, however the matrices are
+Recall from \Cref{sec:vector_space_linear_maps} that a linear map from an
+$n$-dimensional vector space to an $m$-dimensional vector space can be written as
+an $m \times n$ matrix. Here the situation is similar, however the matrices are
 made for each irrep independently, and the non-isomorphic irreps, in some sense,
-``doesn't talk to each other''.
+``don't talk to each other''.
 
 %We can compare this to \Cref{prop:rep_direct_sum}: When our $k$-algebra is a
 %direct sum $A \oplus B$, then every representation $V$ can be broken down
@@ -160,7 +160,7 @@ made for each irrep independently, and the non-isomorphic irreps, in some sense,
 		\end{pmatrix}
 		\begin{bmatrix}
 			c_{11} & c_{21} & \cdots & c_{(m-1)1} & c_{m1} \\
-			c_{12} & c_{22} & \cdots & c_{(m-1)1} & c_{m2} \\
+			c_{12} & c_{22} & \cdots & c_{(m-1)2} & c_{m2} \\
 			\vdots & \vdots & \ddots & \vdots & \vdots \\
 			c_{1n} & c_{2n} & \cdots & c_{(m-1)n} & c_{mn}
 		\end{bmatrix}
@@ -280,7 +280,7 @@ This also gives us the non-obvious corollary:
 
 	Because we're working through a counterexample, pick $e_1=(1, 0)$, $e_2=(2, 0)$ instead.
 	Then, for some $w_1, w_2 \in V$,
-	there may be no $a$ that sends $e_1$ to $w_1$ to $e_2$ to $w_2$.
+	there may be no $a$ that sends $e_1$ to $w_1$ and $e_2$ to $w_2$.
 
 	Consider the representation morphism $\Reg(A) \to V^{\oplus 2}$ by
 	$a \mapsto(a \cdot e_1, a \cdot e_2)$;
@@ -313,7 +313,7 @@ This also gives us the non-obvious corollary:
 \end{theorem}
 \begin{proof}
 	(i) $\implies$ (ii) follows from
-	using \Cref{prop:rep_direct_sum} to breaks any finite-dimensional
+	using \Cref{prop:rep_direct_sum} to break any finite-dimensional
 	representation of $A$ into a direct sum of representations of
 	$\Mat_{d_i}(k)$, then \Cref{thm:rep_1mat} shows any such representations are
 	completely reducible.
@@ -362,7 +362,7 @@ the density theorem (and \Cref{cor:finiteness}), we obtain:
 	equality holds exactly when $A$ is semisimple,
 	in which case
 	\[ \Reg(A) \cong \bigoplus_i \Mat(V_i)
-		\cong \bigoplus_I V_i^{\oplus \dim V_i}. \]
+		\cong \bigoplus_i V_i^{\oplus \dim V_i}. \]
 \end{theorem}
 \begin{proof}
 	The inequality was already mentioned in \Cref{cor:finiteness}.


### PR DESCRIPTION
Proofreading pass over the **Representation Theory** part (issue #315), covering `tex/rep-theory/rep-alg.tex`, `semisimple.tex`, `characters.tex`, and `applications.tex`. All findings are minor (typos, grammar, notation). No mathematical arguments were rewritten.

### `semisimple.tex`
- **Transposed matrix dimensions.** Napkin's `sec:vector_space_linear_maps` fixes the convention that a map from an $m$-dimensional domain to an $n$-dimensional codomain is an $n \times m$ matrix (codomain rows × domain columns). Two spots had the order reversed:
  - "$\Homrep(V^{\oplus n}, V^{\oplus m})$ consist of $n \times m$ matrices" → `consists of $m \times n$`. The map is $V^{\oplus n}\to V^{\oplus m}$, and the displayed matrix immediately after is genuinely $m$ rows × $n$ columns.
  - "a linear map from an $n$-dimensional ... to an $m$-dimensional ... can be written as a $n \times m$ matrix" → `$m \times n$`, matching the cited section.
- "the second arrow is **inclusion** to the $j$th component" → **projection** onto (the arrow in the diagram is the surjection $V^{\oplus n}\surjto V$).
- Stray matrix index in the "stacked horizontally" remark: row 2 had `c_{(m-1)1}` → `c_{(m-1)2}`.
- "sends $e_1$ to $w_1$ **to** $e_2$ to $w_2$" → "**and** $e_2$".
- "to **breaks** any finite-dimensional representation" → "to **break**".
- `\bigoplus_I` → `\bigoplus_i` (capital subscript typo).
- Grammar: "a linear **maps**" → "a linear map"; "irreps ... **doesn't** talk" → "**don't** talk".

### `characters.tex`
- "the character $\chi_V$ ... attached to **$A$**" → attached to **$V$** (the character is attached to the representation).
- "characters of finite-dimensional irreps of **$V$**" → "irreps of **$A$**".
- Notation: "$A = \Mat_k(d)$" → "$A = \Mat_d(k)$" (matches usage everywhere else).

### `applications.tex`
- "$\Tr T = \lambda_i \dim V$" → "$\Tr T_i$" (the operator is $T_i$).
- "be **an** complex irrep" → "**a** complex irrep".
- "second orthogonality formula applied $g$ and $1_G$" → "applied **to** $g$ and $1_G$".
- "each element of $H$ acts trivially **in $G$**" → "acts trivially **on $V$**" (the point is that $H$ lies in $\ker\rho$, so it acts as the identity on $V$).

No issues found in `rep-alg.tex`.

Part of the proofreading campaign (#315).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4ky3kJnfS3bwr4ZZrvbKk

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4ky3kJnfS3bwr4ZZrvbKk)_