### PR TITLE
fix: proofread Quantum Algorithms part

### DIFF
--- a/tex/quantum/circuits.tex
+++ b/tex/quantum/circuits.tex
@@ -7,7 +7,7 @@ linear combinations of $0$ and $1$.
 
 \section{Classical logic gates}
 In classical logic, we build circuits which take in some bits for input,
-and output some more bits for input.
+and output some more bits for output.
 These circuits are built out of individual logic gates.
 For example, the \vocab{AND gate} can be pictured as follows.
 \[
@@ -109,7 +109,7 @@ Of course, the first theorem you learn about these gates is that:
 For the purposes of quantum mechanics, this is not enough.
 To carry through the analogy we in fact need gates that are \vocab{reversible},
 meaning the gates are bijections from the input space to the output space.
-In particular, such gates must take the same number of input and output gates.
+In particular, such gates must take the same number of input and output bits.
 \begin{example}[Reversible gates]
 	\listhack
 	\begin{enumerate}[(a)]
@@ -340,7 +340,7 @@ even when the original inputs are not entangled.
 		\ii Every reversible classical gate that we encountered before
 		has a quantum analog obtained in the same way as CNOT:
 		by specifying the values on basis elements.
-		For example, there is a quantum Tofolli gate which
+		For example, there is a quantum Toffoli gate which
 		for example sends
 		\[
 			\Qcircuit @C=0.8em @R=.7em {
@@ -625,29 +625,29 @@ However,
 	is $1$ if $f$ is constant and $0$ if $f$ is balanced.
 	\begin{hint}
 		First show that the box sends
-		$\ket{x_1} \otimes \dots \otimes \ket{x_m} \otimes \xdown$
-		to $(-1)^{f(x_1, \dots, x_m)}
-		(\ket{x_1} \otimes \dots \otimes \ket{x_m} \otimes \xdown)$.
+		$\ket{x_1} \otimes \dots \otimes \ket{x_n} \otimes \xdown$
+		to $(-1)^{f(x_1, \dots, x_n)}
+		(\ket{x_1} \otimes \dots \otimes \ket{x_n} \otimes \xdown)$.
 	\end{hint}
 	\begin{sol}
 		Put $\xdown = \frac{1}{\sqrt2} (\ket0-\ket1)$.
 		Then we have that $U_f$ sends
 		\[
-			\ket{x_1}  \dots  \ket{x_m}  \ket 0
-			- \ket{x_1}  \dots  \ket{x_m}  \ket 1
+			\ket{x_1}  \dots  \ket{x_n}  \ket 0
+			- \ket{x_1}  \dots  \ket{x_n}  \ket 1
 			\xmapsto{U_f}
-			\pm \ket{x_1}  \dots  \ket{x_m}  \ket 0
-			\mp \ket{x_1}  \dots  \ket{x_m}  \ket 1
+			\pm \ket{x_1}  \dots  \ket{x_n}  \ket 0
+			\mp \ket{x_1}  \dots  \ket{x_n}  \ket 1
 		\]
-		the sign being $+$, $-$ exactly when $f(x_1, \dots, x_m) = 1$.
+		the sign being $+$, $-$ exactly when $f(x_1, \dots, x_n) = 1$.
 
-		Now, upon inputting $\ket0 \dots \ket0 \ket1$, we find that $H^{\otimes m+1}$ maps it to
+		Now, upon inputting $\ket0 \dots \ket0 \ket1$, we find that $H^{\otimes n+1}$ maps it to
 		\[ 2^{-n/2} \sum_{x_1, \dots, x_n} \ket{x_1} \dots \ket{x_n} \xdown.  \]
 		Then the image under $U_f$ is
 		\[ 2^{-n/2} \sum_{x_1, \dots, x_n} (-1)^{f(x_1, \dots, x_n)} \ket{x_1} \dots \ket{x_n} \xdown.  \]
 		We now discard the last qubit, leaving us with
 		\[ 2^{-n/2} \sum_{x_1, \dots, x_n} (-1)^{f(x_1, \dots, x_n)} \ket{x_1} \dots \ket{x_n}.  \]
-		Applying $H^{\otimes m}$ to this, we get
+		Applying $H^{\otimes n}$ to this, we get
 		\[ 2^{-n/2} \sum_{x_1, \dots, x_n} (-1)^{f(x_1, \dots, x_n)}
 			\cdot
 			\left(
@@ -668,7 +668,7 @@ However,
 			C(y_1, \dots, y_n)
 			\ket{y_1} \ket{y_2} \dots \ket{y_n}
 		\]
-		where $C_{y_1, \dots, y_n}
+		where $C(y_1, \dots, y_n)
 		= \sum_{x_1, \dots, x_n} (-1)^{f(x_1, \dots, x_n)
 			+x_1 y_1 + \dots + x_n y_n}$.
 		Now, we finally consider two cases.
@@ -711,7 +711,7 @@ However,
 		}
 	\]
 	This was a big surprise to researchers when discovered,
-	because classical reversible logic requires three-bit gates (e.g. Toffoli, Fredkind).
+	because classical reversible logic requires three-bit gates (e.g. Toffoli, Fredkin).
 	\begin{hint}
 		This is direct computation.
 	\end{hint}

--- a/tex/quantum/shor.tex
+++ b/tex/quantum/shor.tex
@@ -119,7 +119,7 @@ orthonormal basis $\ket0$, $\ket1$, \dots, $\ket{N-1}$
 		\end{bmatrix}
 	\]
 \end{definition}
-This is the exactly the same definition as before,
+This is exactly the same definition as before,
 except we have a $\sqrt N$ factor added so that $\UQFT$ is unitary.
 But the trick is that in the quantum setup, the matrix can be rewritten:
 \begin{proposition}
@@ -225,9 +225,10 @@ first we generate a sequence which is periodic modulo $r$.
 	Applying this to $\ket\psi \otimes \ket0$ gives
 	\[ U(\ket\psi\ket0) =
 		\frac{1}{\sqrt N} \sum_{k=0}^{N-1} \ket k \otimes \ket{x^k \bmod M}. \]
-	Now suppose we measure the second qubit, and get a state of $\ket{128}$.
+	Now suppose we measure the second qubit, and get a state of $\ket{51}$
+		(note that $2^7 \equiv 51 \pmod{77}$).
 	That tells us that the collapsed state now, up to scaling, is
-	\[ (\ket{7} + \ket{7+r} + \ket{7+2r} + \dots) \otimes \ket{128}. \]
+	\[ (\ket{7} + \ket{7+r} + \ket{7+2r} + \dots) \otimes \ket{51}. \]
 \end{example}
 The bottleneck is actually the circuit $U_x$;
 one can compute $x^k \pmod M$ by using repeated squaring,
@@ -253,7 +254,7 @@ but we don't expect $r$ to be.
 
 Nevertheless, consider a state
 \[ \ket\phi = \ket{k_0} + \ket{k_0+r} + \dots \]
-so for example previously we had $k_0=7$ if we measured $128$ on $x=2$.
+so for example previously we had $k_0=7$ if we measured $51$ on $x=2$.
 Applying the quantum Fourier transform, we see that the
 coefficient of $\ket j$ in the transformed image is equal to
 \[

--- a/tex/quantum/vectors.tex
+++ b/tex/quantum/vectors.tex
@@ -178,7 +178,7 @@ This behavior is called \vocab{quantum collapse}.
 	it has now been projected onto the eigenspace $H_\lambda$.
 	In still other words, after observation, the state collapses to
 	\[
-		\sum_{\substack{0 \le i \le n \\ \substack{\lambda_i = \lambda}}}
+		\sum_{\substack{0 \le i \le n-1 \\ \lambda_i = \lambda}}
 		c_i \ket{i}_T.
 	\]
 \end{itemize}
@@ -458,7 +458,7 @@ That's what entangled states mean: the qubits somehow depend on each other.
 		span one eigenspace of $\sigma_x^A \otimes \id_B$,
 		and $\xdown_A \otimes \xup_B$, $\xdown_A \otimes \xdown_B$
 		span the other. So this is the same as before:
-		$+1$ gives $\xdown_B$ and $-1$ gives $\xdown_A$.
+		$+1$ gives $\xdown_B$ and $-1$ gives $\xup_B$.
 	\end{sol}
 \end{problem}
 


### PR DESCRIPTION
Proofreading pass over the **Quantum Algorithms** part (`tex/quantum/vectors.tex`, `circuits.tex`, `shor.tex`), part of the proofreading campaign (#315).

Most fixes are minor typos/grammar; two are small calculation/logic errors worth highlighting.

### `vectors.tex`
- **Singlet-state measurement (logic error).** In the problem solution for measuring $\sigma_x^A \otimes \id_B$ on $\ket{\Psi_-}$, the text read "$+1$ gives $\xdown_B$ and $-1$ gives $\xdown_A$". The question asks for the state of qubit $B$, and from $\ket{\Psi_-} = -\tfrac{1}{\sqrt2}(\xup_A\otimes\xdown_B - \xdown_A\otimes\xup_B)$, the $-1$ outcome ($\xdown_A$) leaves $B$ in $\xup_B$. Fixed to "$-1$ gives $\xup_B$".
- Eigenspace-projection collapse sum: index range $0 \le i \le n$ → $0 \le i \le n-1$ (basis is $\ket0,\dots,\ket{n-1}$), and removed a redundant nested `\substack`.

### `circuits.tex`
- Grammar: "output some more bits for input" → "for output".
- "such gates must take the same number of input and output **gates**" → "**bits**".
- Spelling: "Tofolli" → "Toffoli"; "Fredkind" → "Fredkin".
- Deutsch–Jozsa problem solution mixed the qubit count $m$ and $n$ within the same formulas (e.g. $H^{\otimes m+1}$ alongside $\sum_{x_1,\dots,x_n}$). Unified everything to $n$ to match the problem statement, and made the $C(y_1,\dots,y_n)$ notation consistent.

### `shor.tex`
- Grammar: "This is **the** exactly the same definition" → "This is exactly the same definition".
- **Worked example $M=77$ (calculation error).** With $x=2$, the second register holds $x^k \bmod 77$, a residue $< 77$, so the measured state cannot be $\ket{128}$. Since $2^7 = 128 \equiv 51 \pmod{77}$, the measured value (and the tensor factor in the collapsed state) should be $\ket{51}$; corrected in all three places it appears. ($k_0 = 7$ and the later continued-fraction computation are unaffected and check out.)

No large mathematical errors found; the arguments are otherwise sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgxZuhRMToc13PJS4jaWo6)_