### PR TITLE
fix: proofread Calculus 101 part

### DIFF
--- a/tex/calculus/differentiate.tex
+++ b/tex/calculus/differentiate.tex
@@ -595,7 +595,7 @@ By convention, $f^{(0)} = f$.
 Most of the functions we encounter,
 such as polynomials, $e^x$, $\log$, $\sin$, $\cos$
 are smooth, and so are their compositions.
-Here is a weird example which we'll see more of next time.
+Here is a weird example which we'll grow more next time.
 \begin{example}
 	[A smooth function with all derivatives zero]
 	Consider the function

--- a/tex/calculus/differentiate.tex
+++ b/tex/calculus/differentiate.tex
@@ -27,7 +27,7 @@ I suspect most of you have seen this before, but:
 	The function $f$ is differentiable if it is differentiable
 	at every point.
 	In that case, we regard the derivative $f' \colon (a,b) \to \RR$
-	as a function it its own right.
+	as a function in its own right.
 \end{definition}
 
 \begin{exercise}
@@ -131,10 +131,10 @@ Sum rule, all that jazz.
 	In what follows $f$ and $g$ are differentiable functions,
 	and $U$, $V$ are open subsets of $\RR$.
 	\begin{itemize}
-		\ii (Sum rule) If $f,g \colon U \to \RR$ then
+		\ii (Sum rule) If $f,g \colon U \to \RR$
 		then $(f+g)'(x) = f'(x) + g'(x)$.
 
-		\ii (Product rule) If $f,g \colon U \to \RR$ then
+		\ii (Product rule) If $f,g \colon U \to \RR$
 		then $(f \cdot g)'(x) = f'(x) g(x) + f(x) g'(x)$.
 
 		\ii (Chain rule) If $f \colon U \to V$ and $g \colon V \to \RR$
@@ -305,7 +305,7 @@ We will give a rigorous description of how to do this here.
 		it is a local maximum of $-f$.}
 \end{definition}
 \begin{definition}
-	A point $p$ is a \vocab{local extrema}
+	A point $p$ is a \vocab{local extremum}
 	if it satisfies either of these.
 \end{definition}
 
@@ -313,7 +313,7 @@ The nice thing about derivatives is that they pick up all extrema.
 \begin{theorem}
 	[Fermat's theorem on stationary points]
 	Suppose $f \colon U \to \RR$ is differentiable
-	and $p \in U$ is a local extrema.
+	and $p \in U$ is a local extremum.
 	Then $f'(p) = 0$.
 \end{theorem}
 
@@ -333,7 +333,7 @@ If you draw a picture, this result is not surprising.
 \end{center}
 (Note also: the converse is not true.
 Say, $f(x) = x^{2019}$ has $f'(0) = 0$
-but $x=0$ is not a local extrema for $f$.)
+but $x=0$ is not a local extremum for $f$.)
 
 \begin{proof}
 	Assume for contradiction $f'(p) > 0$.
@@ -357,10 +357,10 @@ we change the domain to be a compact set $Z$,
 for which we know that $f$ will achieve some global maximum.
 The set $Z$ will naturally have some \emph{interior} $S$,
 and calculus will give us all the extrema within $S$.
-Then we manually check all cases outside $Z$.
+Then we manually check all cases outside $S$.
 
 Let's see two extended examples.
-The one is simple, and you probably already know about it,
+The first one is simple, and you probably already know about it,
 but I want to show you how to use compactness to argue thoroughly,
 and how the ``boundary'' points naturally show up.
 
@@ -461,7 +461,7 @@ One can adapt the theorem as follows.
 \end{theorem}
 
 Pictorially, there is a $c$ such that the tangent at $c$
-has the same slope as the secant joining $(a, f(a))$, to $(b, f(b))$;
+has the same slope as the secant joining $(a, f(a))$ to $(b, f(b))$;
 and Rolle's theorem is the special case where that secant is horizontal.
 
 \begin{center}
@@ -513,7 +513,7 @@ and Rolle's theorem is the special case where that secant is horizontal.
 \end{remark}
 
 The mean value theorem is important because it lets
-you relate \textbf{use derivative information
+you \textbf{use derivative information
 to get information about the function}
 in a way that is really not possible without it.
 Here is one quick application to illustrate my point:
@@ -595,7 +595,7 @@ By convention, $f^{(0)} = f$.
 Most of the functions we encounter,
 such as polynomials, $e^x$, $\log$, $\sin$, $\cos$
 are smooth, and so are their compositions.
-Here is a weird example which we'll grow more next time.
+Here is a weird example which we'll see more of next time.
 \begin{example}
 	[A smooth function with all derivatives zero]
 	Consider the function

--- a/tex/calculus/integrate.tex
+++ b/tex/calculus/integrate.tex
@@ -24,8 +24,8 @@ but functions on compact sets are always uniformly continuous.}
 	for all $\eps > 0$ there exists a $\delta > 0$ such that
 	\[ d_M(p,q) < \delta \implies d_N(f(p), f(q)) < \eps. \]
 \end{definition}
-This difference is that given an $\eps > 0$ we must specify a $\delta > 0$
-which works for \emph{every} choice $p$ and $q$ of inputs;
+The difference is that given an $\eps > 0$ we must specify a $\delta > 0$
+which works for \emph{every} choice of inputs $p$ and $q$;
 whereas usually $\delta$ is allowed to depend on $p$ and $q$.
 (Also, this definition can't be ported
 to a general topological space.)
@@ -193,7 +193,7 @@ I need to introduce a bit of notation so bear with me.
 Warning: only $C^0([a,b])$ is common notation,
 and the other two are made up.
 
-See picture below for a typical a rectangle function.
+See picture below for a typical rectangle function.
 (It is irritating that we have to officially assign a single
 value to each $t_i$,
 even though there are naturally two values we want to use,
@@ -314,8 +314,8 @@ We denote this function by
 The above definition might seem fantastical, overcomplicated,
 hilarious, or terrible, depending on your taste.
 But if you unravel it, it's really the picture you are used to.
-What we have done is taking every continuous function $f \colon [a,b] \to \RR$
-and showed that it can be approximated by a rectangle function
+What we have done is take every continuous function $f \colon [a,b] \to \RR$
+and show that it can be approximated by a rectangle function
 (which we phrased as a dense inclusion).
 Then we added the area of the rectangles.
 Nonetheless, we will give a definition that's
@@ -323,7 +323,7 @@ more like what you're used to seeing in other places.
 \begin{definition}
 	A \emph{tagged partition} $P$ of $[a,b]$
 	consists of a partition of $[a,b]$ into $n$ intervals,
-	with a point $\xi_i$ in the $n$th interval, denoted
+	with a point $\xi_i$ in the $i$th interval, denoted
 	\[ a = t_0 < t_1 < t_2 < \dots < t_n = b
 		\qquad\text{and}\qquad \xi_i \in [t_{i-1}, t_i]
 		\quad \forall \; 1 \le i \le n.  \]
@@ -371,8 +371,8 @@ but the $\xi_i$ are the sample points.
 	The right-hand side corresponds to the areas
 	of some rectangle functions $g_1$, $g_2$, \dots
 	with increasingly narrow rectangles.
-	As in the proof \Cref{thm:gaitsgory_riemann},
-	as the meshes of those rectangles approaches zero,
+	As in the proof of \Cref{thm:gaitsgory_riemann},
+	as the meshes of those rectangles approach zero,
 	by uniform continuity, we have $d(f, g_n) \to 0$ as well.
 	Thus by continuity in the diagram of \Cref{thm:gaitsgory_riemann},
 	we get $\lim_n \Sigma(g_n) = \int(f)$ as needed.

--- a/tex/calculus/limits.tex
+++ b/tex/calculus/limits.tex
@@ -5,7 +5,7 @@ of metric (and topological) spaces well,
 we give a three-chapter sequence which
 briskly covers the theory of single-variable calculus.
 
-Much of the work has secretly already been done,
+Much of the work has secretly already been done.
 For example, if $x_n$ and $y_n$ are real sequences
 with $\lim_n x_n = x$ and $\lim_n y_n = y$,
 then in fact $\lim_n (x_n + y_n) = x+y$
@@ -81,8 +81,8 @@ To write it out:
 \end{theorem}
 
 \begin{definition}
-	For convenience, if $S$ has not bounded above, we write $\sup S = +\infty$.
-	Similarly, if $S$ has not bounded below, we write $\inf S = -\infty$.
+	For convenience, if $S$ is not bounded above, we write $\sup S = +\infty$.
+	Similarly, if $S$ is not bounded below, we write $\inf S = -\infty$.
 \end{definition}
 
 \begin{example}
@@ -235,7 +235,7 @@ as the real line, and slicing at some real number.
 The subset $\QQ \subset \RR$ gets cut into two halves $A$ and $B$.
 If the knife happens to land exactly at a rational number,
 by convention we consider that number to be in the right half
-(which explains the last fourth condition that $\sup A \notin A$).
+(which explains the last condition that $\sup A \notin A$).
 
 With this definition \Cref{thm:inf_sup} is easy:
 to take the supremum of a set of real numbers,
@@ -259,7 +259,7 @@ Here is a great exercise.
 	you can also try to use completeness of $\RR$.
 	Second hint: if you are really stuck,
 	wait until after \Cref{thm:nonneg_bounded},
-	at which point you can use essentially copy its proof.
+	at which point you can essentially copy its proof.
 \end{exercise}
 
 The proof here readily adapts by shifting.
@@ -287,7 +287,7 @@ The proof here readily adapts by shifting.
 		a_5 &= 1.2481632 \\
 		&\vdotswithin=
 	\end{align*}
-	and so on, where in general we stuck
+	and so on, where in general we tack
 	on the decimal representation of the next power of $2$.
 	This will converge to \emph{some} real number,
 	although of course this number
@@ -344,7 +344,7 @@ We can think of $\limsup_n a_n$ as
 
 
 \section{Infinite series}
-\prototype{$\sum_{k \ge 1}^\infty \frac{1}{k(k+1)}
+\prototype{$\sum_{k=1}^\infty \frac{1}{k(k+1)}
 = \lim_{n \to \infty} \left( 1 - \frac{1}{n+1} \right) = 1$.}
 
 We will actually begin by working with infinite series,
@@ -817,7 +817,7 @@ I've mentioned this, so I will not say more.
 			&\le a_M \\
 			a_M - a_{M+1} + a_{M+2} - \dots
 			&= a_M - a_{M+1} + (a_{M+2} - a_{M+3}) + (a_{M+4} - a_{M+5}) \\
-			&\quad+ \dots + (a_{N-2} - a_{N+1}) + a_N \\
+			&\quad+ \dots + (a_{N-2} - a_{N-1}) + a_N \\
 			&\ge -a_{M+1}.
 		\end{align*}
 		In this way we see that the sequence of partial sums is Cauchy,

--- a/tex/calculus/p-adic.tex
+++ b/tex/calculus/p-adic.tex
@@ -318,7 +318,7 @@ So you can divide by $p$ with no repercussions.
 Up until now we've been thinking about things mostly algebraically,
 but moving forward it will be helpful to start using the language of analysis.
 Usually, two real numbers are considered ``close'' if
-they are close on the number of line,
+they are close on the number line,
 but for $p$-adic purposes we only care about modulo $p^e$ information.
 So, we'll instead think of two elements of $\ZZ_p$ or $\QQ_p$
 as ``close'' if they differ by a large multiple of $p^e$.
@@ -350,7 +350,7 @@ in that case $\nu_p(x-y)$ is large
 and accordingly $\left\lvert x-y \right\rvert_p$ is small.
 
 \subsection{Ultrametric space}
-In this way, $\QQ_p$ and $\ZZ_p$ becomes a metric space
+In this way, $\QQ_p$ and $\ZZ_p$ become metric spaces
 with metric given by $\left\lvert x-y \right\rvert_p$.
 
 \begin{exercise}
@@ -579,7 +579,7 @@ in the following way.
 \end{theorem}
 The $a_i$ are called the \emph{Mahler coefficients} of $f$.
 \begin{exercise}
-	Last post we proved that if $f \colon \ZZ_p \to \QQ_p$ is continuous
+	Earlier we proved that if $f \colon \ZZ_p \to \QQ_p$ is continuous
 	and $f(n) = (-1)^n$ for every $n \in \ZZ_{\ge 0}$ then $p = 2$.
 	Re-prove this using Mahler's theorem,
 	and this time show conversely that a unique such $f$ exists when $p=2$.
@@ -644,7 +644,7 @@ which was interesting even before $p$-adics came along!
 	Let $T$ be an integer such that $A^T \equiv \id \pmod p$
 	(with $\id$ denoting the identity matrix).
 
-	Fix any $0 \le r < N$.
+	Fix any $0 \le r < T$.
 	We will prove that either all the terms
 	\[ f(n) = x_{nT+r} \qquad n = 0, 1, \dots \]
 	are zero, or at most finitely many of them are.
@@ -655,9 +655,9 @@ which was interesting even before $p$-adics came along!
 	\begin{align*}
 		f(n) &= \left< A^{nT+r} u, v \right>
 		= \left< (\id + pB)^n A^r u, v \right> \\
-		&= \sum_{k \ge 0} \binom nk \cdot p^n \left< B^n A^r u, v \right> \\
-		&= \sum_{k \ge 0} a_n \binom nk \qquad \text{ where }
-			a_n = p^n \left< B^n A^r u, v \right> \in p^n \ZZ.
+		&= \sum_{k \ge 0} \binom nk \cdot p^k \left< B^k A^r u, v \right> \\
+		&= \sum_{k \ge 0} a_k \binom nk \qquad \text{ where }
+			a_k = p^k \left< B^k A^r u, v \right> \in p^k \ZZ.
 	\end{align*}
 	Thus we have written $f$ in Mahler form.
 	Initially, we define $f \colon \ZZ_{\ge 0} \to \ZZ$,
@@ -666,7 +666,7 @@ which was interesting even before $p$-adics came along!
 	Also, we can check that $\lim_n \frac{a_n}{n!} = 0$
 	hence $f$ is even analytic.
 
-	Thus by Strassman's theorem, $f$ is either identically zero,
+	Thus by Strassmann's theorem, $f$ is either identically zero,
 	or else it has finitely many zeros, as desired.
 \end{proof}
 

--- a/tex/calculus/taylor.tex
+++ b/tex/calculus/taylor.tex
@@ -85,13 +85,13 @@ So we define the main character now.
 Now, if I plug in a \emph{particular} real number $h$,
 then I get a series of real numbers $\sum_{n = 0}^{\infty} a_n h^n$.
 So I can ask, when does this series converge?
-It terms out there is a precise answer for this.
+It turns out there is a precise answer for this.
 
 \begin{definition}
 	Given a power series $\sum_{n=0}^{\infty} a_n z^n$,
 	the \vocab{radius of convergence} $R$ is defined
 	by the formula
-	\[ \frac 1R = \limsup_{n \to \infty} \left\lvert a_n \right\rvert^{1/n}. \]
+	\[ \frac 1R = \limsup_{n \to \infty} \left\lvert a_n \right\rvert^{1/n} \]
 	with the convention that $R = 0$ if the right-hand side is $\infty$,
 	and $R = \infty$ if the right-hand side is zero.
 \end{definition}
@@ -144,7 +144,7 @@ this means we get a function $\RR \to \RR$.
 	which sometimes we will plug in a real number for,
 	but that happens only after the polynomial is defined.
 
-	Despite this, ``the polynomial $p(x) = x^3+7x+9$''
+	Despite this, ``the polynomial $P(x) = x^3+7x+9$''
 	(which can be thought of as the coefficients)
 	and ``the real-valued function $x \mapsto x^3+7x+9$''
 	are often used interchangeably.


### PR DESCRIPTION
This proofreads the **Calculus 101** part (the first unchecked box in #315), covering the five chapters under `tex/calculus/`: `limits.tex`, `p-adic.tex`, `differentiate.tex`, `taylor.tex`, `integrate.tex`.

All findings were minor (typos, grammar, and small index slips). No large mathematical errors were found.

### `limits.tex`
- Comma splice "…already been done, / For example" → period.
- "if $S$ **has** not bounded above/below" → "**is** not bounded".
- Malformed prototype sum `\sum_{k \ge 1}^\infty` → `\sum_{k=1}^\infty`.
- "you can **use** essentially copy its proof" → drop stray "use".
- "where in general we **stuck** on the decimal representation" → "**tack**".
- "the **last fourth** condition" → "the last condition".
- **Index typo** in the alternating series test solution: `(a_{N-2} - a_{N+1})` → `(a_{N-2} - a_{N-1})`.

### `p-adic.tex`
- "close on the number **of** line" → "number line".
- "$\QQ_p$ and $\ZZ_p$ **becomes** a metric space" → "**become** metric spaces".
- "**Last post** we proved" → "**Earlier** we proved" (leftover blog phrasing).
- Skolem–Mahler–Lech proof: "Fix any $0 \le r < N$" used an undefined $N$ → "$< T$".
- Mahler-form expansion of $(\id+pB)^n$: summation terms were indexed by $n$ instead of the summation variable $k$ (`p^n`, `B^n`, `a_n` → `p^k`, `B^k`, `a_k`).
- "**Strassman**'s theorem" → "**Strassmann**'s" (matches the earlier spelling in the same chapter).

### `differentiate.tex`
- "as a function **it** its own right" → "**in** its own right".
- Duplicated "then **then**" in the sum and product rule statements.
- Singular "local **extrema**" → "local **extremum**" (3 spots).
- "manually check all cases outside $Z$" → "outside $S$" (the interior; boundary points lie in $Z\setminus S$).
- "**The one** is simple" → "The first one is simple".
- Stray word: "it lets you **relate** **use** derivative information…" → drop "relate".
- Extra comma in "secant joining $(a,f(a))$**,** to $(b,f(b))$".
- "which we'll **grow more** next time" → "which we'll see more of next time".

### `taylor.tex`
- "It **terms** out" → "It **turns** out".
- Stray period inside the radius-of-convergence display before "with the convention".
- "$p(x) = x^3+7x+9$" → "$P(x)$" to match the surrounding text.

### `integrate.tex`
- "**This** difference is that…" → "**The** difference is that…".
- "a typical **a** rectangle function" → drop extra "a".
- "What we have done is **taking** … and **showed**" → "is **take** … and **show**".
- "a point $\xi_i$ in the **$n$th** interval" → "**$i$th** interval".
- "As in the proof **\Cref{…}**" → "As in the proof **of** \Cref{…}".
- "the meshes … **approaches** zero" → "**approach** zero".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLpJ1D8Tg8VgMKgGB5iAhg)_