### PR TITLE
fix: proofread Complex Analysis part

### DIFF
--- a/tex/complex-ana/holomorphic.tex
+++ b/tex/complex-ana/holomorphic.tex
@@ -535,7 +535,7 @@ So let's state the full result below, with arbitrary center $p$.
 	\]
 	where
 	\[
-		c_k = \frac{f^{k}(p)}{k!} = \frac{1}{2\pi i} \oint_\gamma \frac{f(w)}{(w-p)^{k+1}} \; dw
+		c_k = \frac{f^{(k)}(p)}{k!} = \frac{1}{2\pi i} \oint_\gamma \frac{f(w)}{(w-p)^{k+1}} \; dw
 	\]
 	In particular,
 	\[ f^{(k)}(p) = k! c_k = \frac{k!}{2\pi i} \oint_\gamma \frac{f(w)}{(w-p)^{k+1}} \; dw. \]
@@ -573,7 +573,7 @@ but in fact equal to its Taylor series.
 \end{remark}
 
 \begin{remark}
-	You can see where the term $\frac{f(w-p)}{(w-p)^{k+1}}$ comes from in
+	You can see where the term $\frac{f(w)}{(w-p)^{k+1}}$ comes from in
 	\Cref{remark:cauchy_integral_intuition}. It is very intuitive that even if you forget it,
 	you can derive it yourself as well!
 \end{remark}
@@ -592,7 +592,7 @@ the existence of a Taylor series is incredibly powerful.
 \section{Optional: Proof that holomorphic functions are analytic}
 
 It is recommended to read the next chapter first to understand the origin of the term
-$\frac{f(w-p)}{(w-p)^{k+1}}$ in Cauchy's differentiation formula above.
+$\frac{f(w)}{(w-p)^{k+1}}$ in Cauchy's differentiation formula above.
 
 Each step of the proof is quite intuitive, if not a bit long.
 The outline is:

--- a/tex/complex-ana/log.tex
+++ b/tex/complex-ana/log.tex
@@ -72,8 +72,8 @@ the points $w_5$ and $w_7$!
 The nearby point $w_6$ has been mapped very far away.
 This discontinuity occurs since the points on the negative real axis are
 at the ``boundary''.
-For example, given $-4$, we send it to $-2i$, but we have hit the boundary:
-in our interval $-\half\pi \le \alpha < \half\pi$, we are at the very left edge.
+For example, given $-4$, we send it to $2i$, but we have hit the boundary:
+in our interval $-\half\pi < \alpha \le \half\pi$, we are at the very right edge.
 
 
 The negative real axis that we must not touch
@@ -258,7 +258,7 @@ That means that for any loop $\gamma$ in $V$, we need $f \circ \gamma$ to have a
 \emph{even} winding number around $0 \in B$.
 This amounts to
 \[
-	\frac{1}{2\pi} \oint_\gamma \frac{f'}{f} \; dz \in 2\ZZ
+	\frac{1}{2\pi i} \oint_\gamma \frac{f'}{f} \; dz \in 2\ZZ
 \]
 since $f$ has no poles.
 

--- a/tex/complex-ana/meromorphic.tex
+++ b/tex/complex-ana/meromorphic.tex
@@ -211,7 +211,7 @@ We can now give many more examples.
 	has infinitely many poles: the numbers $z = \pi k$, where $k$ is an integer.
 	Let's compute the Laurent series at just $z=0$:
 	\begin{align*}
-		\frac{1}{\sin(2\pi z)}
+		\frac{1}{\sin(z)}
 		&= \frac{1}{\frac{z}{1!} - \frac{z^3}{3!} + \frac{z^5}{5!} - \dotsb} \\
 		% &= \frac{1/z}{\frac{1}{1!} - \frac{z^2}{3!} + \frac{z^4}{5!} - \dotsb} \\
 		&= \frac 1z \cdot \frac{1}{1 - \left( \frac{z^2}{3!} - \frac{z^4}{5!} + \dotsb \right)} \\
@@ -479,7 +479,7 @@ point of $\gamma$.
 We all know that $z \mapsto \log z$ is not an actual function --- even ignoring the singularity
 at $0$, it has a branch cut (we will formally handle this in \Cref{ch:complex_log}).
 
-Nevertheless, if we close our eyes and shuffling some symbols around, we get:
+Nevertheless, if we close our eyes and shuffle some symbols around, we get:
 \begin{align*}
 	\frac{1}{2 \pi i} \oint_\gamma \frac{f'(z)}{f(z)} \; dz
 	&= \frac{1}{2 \pi i} \oint_\gamma \frac{d}{dz} \log f(z) \; dz \\
@@ -492,10 +492,10 @@ Now, if $\gamma$ is a circle, then $a = b$, so the formula above seemingly state
 integral will be $0$?
 Fortunately for us, no --- $\log$ is in fact not a function.
 
-So, does the formula above means anything?
+So, does the formula above mean anything?
 It does! While we won't prove this rigorously, the point is that:
 \begin{moral}
-	If we let a point $p$ smoothly moves from $a$ to $b$, and let $\log f(p)$ follows the value,
+	If we let a point $p$ smoothly move from $a$ to $b$, and let $\log f(p)$ follow the value,
 	then $\log f(b) - \log f(a)$ represents the change in value of $\log f(p)$.
 \end{moral}
 

--- a/tex/complex-ana/quintic.tex
+++ b/tex/complex-ana/quintic.tex
@@ -36,8 +36,8 @@ Suppose I told you that some rational function $R$ always finds
 a root of a quintic polynomial $P(z) = (z - z_1)(z - z_2)(z - z_3)(z - z_4)(z - z_5)$.
 For simplicity, let all the roots be distinct.
 
-Suppose that initially $R$ outputs $z_1$. Consider what happens we smoothly swap the roots $z_1$ and $z_2$
-along two non-intersecting paths that doesn't go through other roots.
+Suppose that initially $R$ outputs $z_1$. Consider what happens when we smoothly swap the roots $z_1$ and $z_2$
+along two non-intersecting paths that don't go through other roots.
 
 \begin{center}
 	%% First Diagram
@@ -134,7 +134,7 @@ How do we handle the nested radicals now?
 \begin{example}[Cubic Formula]
 	The cubic formula contains a nasty term
 	\[
-		\sqrt[3]{\frac{2b^3 - 9abc + 27a^2d + \sqrt{(2b^3 - 9abc + 27a^d)^2 - 4(b^3 - 3ac)^3}}{2}}.
+		\sqrt[3]{\frac{2b^3 - 9abc + 27a^2d + \sqrt{(2b^3 - 9abc + 27a^2d)^2 - 4(b^2 - 3ac)^3}}{2}}.
 	\]
 	Here, we've taken multiple roots.
 \end{example}
@@ -152,7 +152,7 @@ we can again consider the \emph{commutators} of these commutators,
 say $\sigma\rho\sigma^{-1}\rho^{-1}$
 which by the same logic fixes the issues with phase.
 
-There's no reason, we can't consider the commutators of commutators of commutators to fix
+There's no reason we can't consider the commutators of commutators of commutators to fix
 radicals of degree $3$ and so on. It thus just remains that we always can keep getting
 nontrivial commutators.
 
@@ -161,7 +161,7 @@ We've reduced this to a group theory problem. Given a chain of commutators
 \[
 	S_5 = G \supseteq G^{(1)} \supseteq G^{(2)} \supseteq \dots
 \]
-where each group is the commutator subgroup of the next,
+where each group is the commutator subgroup of the previous,
 we want to show that $G^{(n)}$ never becomes trivial.
 This chain is called the \vocab{derived series}.
 
@@ -171,7 +171,7 @@ This chain is called the \vocab{derived series}.
 \end{exercise}
 
 \begin{definition}
-	A group $G$ is \vocab{solvable} if its derived series is nontrivial.
+	A group $G$ is \vocab{solvable} if its derived series eventually becomes trivial.
 \end{definition}
 
 So all that remains is showing that $S_5$ is not solvable.


### PR DESCRIPTION
Proofreading pass over the **Complex Analysis** part (issue #315), covering `tex/complex-ana/{holomorphic,meromorphic,log,quintic}.tex`. Findings are mostly minor: typos, missing factors, and a couple of inverted statements.

## `holomorphic.tex`
- **Cauchy's differentiation formula:** the coefficient was written $c_k = \frac{f^{k}(p)}{k!}$; corrected the derivative notation to $f^{(k)}(p)$ (consistent with the lines immediately above and below).
- Two references to the differentiation-formula integrand wrote the numerator as $f(w-p)$; corrected to $f(w)$ to match the theorem statement $\frac{1}{2\pi i}\oint_\gamma \frac{f(w)}{(w-p)^{k+1}}\,dw$.

## `meromorphic.tex`
- **"Function with infinitely many poles" example:** the function is $\frac{1}{\sin(z)}$ (poles at $z=\pi k$), but the Laurent-series computation was headed $\frac{1}{\sin(2\pi z)}$ while its expansion $\frac{1}{z/1! - z^3/3! + \cdots}$ is that of $\frac{1}{\sin z}$. Removed the spurious $2\pi$.
- Minor grammar fixes in the geometric Argument Principle digression ("shuffle", "mean", "move/follow").

## `log.tex`
- **Winding-number integral:** restored the missing $i$, $\frac{1}{2\pi}\oint_\gamma \frac{f'}{f}\,dz \in 2\ZZ \to \frac{1}{2\pi i}\oint_\gamma \frac{f'}{f}\,dz \in 2\ZZ$ (matches the winding-number definition and Theorem on $n$th roots).
- **Worked square-root example:** the surrounding text and the rendered diagram use the branch $-\tfrac\pi2 < \alpha \le \tfrac\pi2$, under which $-4 \mapsto 2i$. The example had written the interval as $-\tfrac\pi2 \le \alpha < \tfrac\pi2$ and the image as $-2i$ ("left edge"); made it consistent ($2i$, "right edge").

## `quintic.tex`
- **Cubic-formula term:** fixed two typos in the discriminant — inner $27a^{d} \to 27a^{2}d$ (matching the outer term) and $(b^{3}-3ac)^3 \to (b^{2}-3ac)^3$ (standard $\Delta_0 = b^2 - 3ac$).
- **Definition of solvable:** was stated inverted ("if its derived series is nontrivial"); corrected to "if its derived series eventually becomes trivial", which is consistent with the goal of showing $S_5$ is *not* solvable (its derived series never reaches the trivial group).
- **Derived series description:** "each group is the commutator subgroup of the next" → "of the previous" ($G^{(k+1)} = [G^{(k)}, G^{(k)}]$).
- Minor grammar fixes ("what happens when we", "paths that don't go", stray comma).

No large mathematical errors were found in this part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoFbVBee5GeFmm74uzR2Mi)_