### PR TITLE
fix: proofread Measure Theory part

### DIFF
--- a/tex/measure/caratheodory.tex
+++ b/tex/measure/caratheodory.tex
@@ -329,8 +329,8 @@ gives a $\sigma$-algebra $\SA\cme$ with a complete measure $\mu\cme$,
 and our two compatibility results
 (namely (b) of \Cref{thm:construct_outer},
 together with \Cref{prop:cm_compatible})
-means that $\SA\cme \supset \SA_0$
-and $\mu\cme$ agrees with $\mu$.
+mean that $\SA\cme \supset \SA_0$
+and $\mu\cme$ agrees with $\mu_0$.
 
 Here is a table showing the process,
 where going down each row of the table corresponds to restriction process.
@@ -406,7 +406,7 @@ Here is an example.
 \begin{example}
 	[The Cantor set has measure zero]
 	The standard \vocab{middle-thirds Cantor set} is the subset
-	$[0,1]$ obtained as follows:
+	of $[0,1]$ obtained as follows:
 	we first delete the open interval $(1/3, 2/3)$.
 	This leaves two intervals $[0,1/3]$ and $[2/3,1]$
 	from which we delete the middle thirds again from both,
@@ -521,7 +521,7 @@ Fortunately, this restriction is trivial to do.
 We will in a moment add this as the fourth row in our table.
 
 However, if this is the end goal,
-than a somewhat different Carath\'{e}odory theorem
+then a somewhat different Carath\'{e}odory theorem
 can be stated because often one more niceness condition holds:
 \begin{definition}
 	A pre-measure or measure $\mu$ on $\Omega$ is \vocab{$\sigma$-finite}
@@ -586,8 +586,8 @@ when $\mu_0$ is $\sigma$-finite.
 \begin{proof}
 	[Proof of \Cref{thm:cara_premeasure}]
 	For (a): this is just \Cref{thm:construct_outer} and \Cref{thm:cara_outer}
-	put together, combined with the observation that $\SA^\ast \supset \SA_0$
-	and hence $\SA^\ast \supset \SA$.
+	put together, combined with the observation that $\SA\cme \supset \SA_0$
+	and hence $\SA\cme \supset \SA$.
 	Parts (b) and (c) are more technical, and omitted.
 \end{proof}
 

--- a/tex/measure/lebesgue-int.tex
+++ b/tex/measure/lebesgue-int.tex
@@ -50,9 +50,9 @@ for $f \colon \Omega \to [0, +\infty]$.
 Note that $[0,+\infty]$ can be thought of as a topological space
 where we add new open sets $(a,+\infty]$ %chktex 9
 for each real number $a$ to our usual basis of open intervals.
-Thus we can equip it with the Borel sigma-algebra.\footnote{We
+Thus we can equip it with the Borel $\sigma$-algebra.\footnote{We
 	\emph{could} also try to define a measure on it,
-	but we will not: it is a good enough for us
+	but we will not: it is good enough for us
 	that it is a measurable space.}
 \begin{step}
 	[Nonnegative functions]
@@ -168,7 +168,7 @@ such that $f(x) = g(x)$ almost everywhere.
 	\[ \int_\Omega cf \; d\mu = c \int_\Omega f \; d\mu. \]
 	The ``absolutely integrable'' hypothesis can be dropped
 	if $f$ is nonnegative and $c > 0$.
-	\ii (Monotoncity)
+	\ii (Monotonicity)
 	If $f$ and $g$ are absolutely integrable and $f \le g$, then
 	\[ \int_\Omega f \; d\mu \le \int_\Omega g \; d\mu. \]
 	The ``absolutely integrable'' hypothesis can be dropped

--- a/tex/measure/measure-space.tex
+++ b/tex/measure/measure-space.tex
@@ -184,7 +184,7 @@ I've gone on too long with no examples.
 	\begin{enumerate}[(a)]
 		\ii If $\Omega$ is any set,
 		then the power set $\SA = 2^{\Omega}$ is obviously a $\sigma$-algebra.
-		This will be used if $\Omega$ is countably finite,
+		This will be used if $\Omega$ is countable,
 		but it won't be very helpful if $\Omega$ is huge.
 		\ii If $\Omega$ is an uncountable set,
 		then we can declare $\SA$ to be all subsets of $\Omega$
@@ -383,7 +383,7 @@ $\int_\Omega f \; d\mu$ exists if and only if $f$ is measurable.
 	Note that a measurable function actually does not need to be continuous,
 	as the next example shows.
 	On the other hand, most functions you actually encounter in practice will be continuous,
-	and in that case ware fine.
+	and in that case we're fine.
 \end{remark}
 \begin{example}
 	[Continuous function with non-measurable preimage of measurable set]

--- a/tex/measure/pontryagin.tex
+++ b/tex/measure/pontryagin.tex
@@ -13,7 +13,7 @@ which is nice because in addition to being a topological space,
 it is also an abelian group under addition.
 These sorts of objects which are both groups and spaces have a name.
 \begin{definition}
-	A group $G$ is a \vocab{topological group}
+	A \vocab{topological group} $G$
 	is a Hausdorff\footnote{Some authors omit the Hausdorff condition.}
 	topological space equipped also with a group operation $(G, \cdot)$,
 	such that both maps
@@ -67,7 +67,7 @@ The relevant theorem, which we will just quote:
 
 \begin{remark}
 	Note that if $G$ is compact, then $\mu(G)$ is finite (and positive).
-	For this reason the Haar measure on a LCA group $G$
+	For this reason the Haar measure on an LCA group $G$
 	is usually normalized so $\mu(G) = 1$.
 \end{remark}
 
@@ -166,11 +166,11 @@ In that case, we get all the results we wanted before:
 The sum $\sum_{\xi \in \wh G}$ makes sense since $\wh G$ is discrete.
 In particular,
 \begin{itemize}
-	\ii Letting $G = Z$ for a finite group $G$
+	\ii Letting $G = Z$ for a finite group $Z$
 	gives ``Fourier transform on finite groups''.
 	\ii The special case $G = \ZZ/n\ZZ$ has its
 	\href{https://en.wikipedia.org/wiki/Discrete_Fourier_transform#Definition}%
-	{own Wikipedia page}: the ``discrete-time Fourier transform''.
+	{own Wikipedia page}: the ``discrete Fourier transform''.
 	\ii Letting $G = \TT$ gives the ``Fourier series'' earlier.
 \end{itemize}
 

--- a/tex/measure/swapsum.tex
+++ b/tex/measure/swapsum.tex
@@ -36,7 +36,7 @@ The limit here is defined in the following sense:
 \begin{definition}
 	Let $f$ and $f_1, f_2, \dots \colon \Omega \to \RR$ be a sequence of functions.
 	Suppose that for each $\omega \in \Omega$, the sequence
-	\[ f_1(\omega), \; f_2(\omega), \; f_3(\omega), \;, \dots \]
+	\[ f_1(\omega), \; f_2(\omega), \; f_3(\omega), \; \dots \]
 	converges to $f(\omega)$.
 	Then we say $f_1$, $f_2$, \dots\ \vocab{converges pointwise}
 	to the limit $f$, written $\lim_{n \to \infty} f_n = f$.
@@ -45,13 +45,13 @@ The limit here is defined in the following sense:
 	and $\limsup_{n \to \infty} f_n$ similarly.
 \end{definition}
 
-By ``the Lebesgue integral has better behavior'', we means the following:
+By ``the Lebesgue integral has better behavior'', we mean the following:
 \begin{proposition}
 	If $f_1, f_2, \dots \colon \Omega \to \RR$ are measurable functions,
 	then $\liminf_{n \to \infty} f_n$ and $\limsup_{n \to \infty} f_n$ are measurable.
 \end{proposition}
 When $f_n$ are all nonnegative, this means
-$\int_\Omega \liminf_{n \to \infty} f_n d\mu$ and $\int_\Omega \limsup_{n \to \infty} f_n d\mu$ exists.
+$\int_\Omega \liminf_{n \to \infty} f_n d\mu$ and $\int_\Omega \limsup_{n \to \infty} f_n d\mu$ exist.
 (If they can be negative, the behavior is not that nice. \Cref{prob:sin_improper} gives an example.)
 
 Unfortunately, even if the integral exists, we can't always exchange pointwise limit with Lebesgue
@@ -93,7 +93,7 @@ Unfortunately, pointwise convergence is actually a fairly weak notion of converg
 	\url{https://www.geogebra.org/m/dv7ctmed} has an animation.}
 \end{example}
 
-As such, the convergence theorems stated below is an attempt to classify all the possible anomalies,
+As such, the convergence theorems stated below are an attempt to classify all the possible anomalies,
 and to show that in ``usual'' cases, interchanging limit and integral just works.
 
 As mentioned earlier, we choose to use the Lebesgue integral instead of the Riemann integral,
@@ -106,7 +106,7 @@ because in such cases, the Lebesgue integral will usually just exist.
 
 \section{Overview}
 The three big-name results for exchanging
-pointwise limits with Lebesgue integrals is:
+pointwise limits with Lebesgue integrals are:
 \begin{itemize}
 	\ii Fatou's lemma: the most general statement possible,
 	for any nonnegative measurable functions.
@@ -156,13 +156,13 @@ when the sequence actually converges, $\liminf$ and $\lim$ equals.
 		\le \liminf_{n \to \infty} \left( \int_\Omega f_n \; d\mu \right).  \]
 	Here we allow either side to be $+\infty$.
 \end{lemma}
-Notice that there are \emph{no extra hypothesis}
+Notice that there are \emph{no extra hypotheses}
 on $f_n$ other than nonnegative: which makes this quite surprisingly versatile
 if you ever are trying to prove some general result.
 
 \section{Everything else}
 The big surprise is how quickly all the ``big-name''
-theorem follows from Fatou's lemma.
+theorems follow from Fatou's lemma.
 Here is the so-called ``monotone convergence theorem''.
 \begin{corollary}
 	[Monotone convergence theorem]
@@ -312,7 +312,7 @@ $|\Omega| < \infty$, the anomaly only happens in a set of \emph{small measure}.
 	\[
 		f_1|_U, f_2|_U, \dots
 	\]
-	converges to $f_U$ uniformly.
+	converges to $f|_U$ uniformly.
 \end{theorem}
 
 This is because of the following theorem.


### PR DESCRIPTION
Proofreading pass over the **Measure Theory** part (issue #315), covering `tex/measure/{measure-space,caratheodory,lebesgue-int,swapsum,pontryagin}.tex`. All findings are minor: typos, grammar, and notation slips.

## `measure-space.tex`
- Power-set example: "if $\Omega$ is countably finite" → "countable" (the contrast in the same sentence is with $\Omega$ being "huge"/uncountable; "countably finite" is not a standard term).
- "and in that case ware fine" → "we're fine".

## `caratheodory.tex`
- Compatibility summary: "$\mu\cme$ agrees with $\mu$" → "$\mu_0$" (at that point in the text only the pre-measure $\mu_0$ exists; the row-4 measure $\mu$ is introduced in the next section). Also "results ... means" → "mean".
- "the subset $[0,1]$" → "the subset of $[0,1]$" (Cantor set).
- "than a somewhat different Carathéodory theorem" → "then".
- Proof of the pre-measure extension theorem: $\SA^\ast$ (undefined) → $\SA\cme$, the notation used everywhere else for the $\sigma$-algebra of $\mu^\ast$-measurable sets (two occurrences).

## `lebesgue-int.tex`
- "the Borel sigma-algebra" → "Borel $\sigma$-algebra" (consistency with the rest of the text).
- "it is a good enough for us" → "it is good enough for us".
- "(Monotoncity)" → "(Monotonicity)".

## `swapsum.tex`
- Pointwise-limit definition: stray comma in the sequence `$f_3(\omega), \;, \dots$` → `$f_3(\omega), \; \dots$`.
- Egorov's theorem: the sequence "converges to $f_U$" → "$f|_U$" (matches the restricted sequence $f_1|_U, f_2|_U, \dots$ just above).
- Subject–verb agreement fixes: "we means" → "mean"; "$\int\dots$ and $\int\dots$ exists" → "exist"; "the convergence theorems ... is an attempt" → "are"; "The three big-name results ... is:" → "are:"; "no extra hypothesis" → "hypotheses"; "all the big-name theorem follows" → "theorems follow".

## `pontryagin.tex`
- Definition of topological group: doubled verb "A group $G$ is a \vocab{topological group} is a Hausdorff ..." → "A \vocab{topological group} $G$ is a Hausdorff ...".
- "the Haar measure on a LCA group" → "on an LCA group".
- $G = \ZZ/n\ZZ$ bullet labelled "discrete-time Fourier transform" but linking to the Discrete Fourier Transform article (and labelled "Discrete Fourier transform" in the summary table) → corrected to "discrete Fourier transform"; the discrete-time Fourier transform is the $G = \ZZ$ case, stated correctly elsewhere.
- "Letting $G = Z$ for a finite group $G$" → "for a finite group $Z$".

No large mathematical errors were found in this part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011vpJKXaRH8HQbTeTqMwocZ)_