### PR TITLE
fix: proofread Probability part

### DIFF
--- a/tex/measure/large-laws.tex
+++ b/tex/measure/large-laws.tex
@@ -32,7 +32,7 @@ In fact, it is almost better for me to give a \emph{non-example}.
 Therefore, for many purposes we need a weaker notion of convergence.
 \begin{definition}
 	Let $X$, $X_n$ be random variables on a probability space $\Omega$.
-	We say $X_n$ \vocab{converges in probability} to $X$ if
+	We say $X_n$ \vocab{converges in probability} to $X$
 	if for every $\eps > 0$ and $\delta > 0$, we have
 	\[ \mu \left( \omega \in \Omega :
 			\left\lvert X_n(\omega) - X(\omega) \right\rvert < \eps
@@ -84,7 +84,7 @@ Then we can ask: What's the expected number of steps until some $X_i$ equals $0$
 
 A naive attempt might be the following.
 \begin{quote}
-	Let $f(i)$ be the expected number of steps starting to reach $0$ starting from $X_0=i$.
+	Let $f(i)$ be the expected number of steps to reach $0$ starting from $X_0=i$.
 
 	Then:
 	\begin{itemize}
@@ -150,7 +150,7 @@ theorem.
 	\end{align*}
 	Formally, $X_i$ takes each of the value in $\{2^k,-2^k\}$ with probability $2^{-k-2}$.
 
-	In this case, the mean $\EE[X_i] = \int_\Omega X_i(\omega)$ is actually undefined.
+	In this case, the mean $\EE[X_i] = \int_\Omega X_i(\omega) \; d\mu$ is actually undefined.
 	Furthermore, as symmetric as the distribution may look, in almost no world will $M_n$ converge
 	to $0$.
 
@@ -168,7 +168,7 @@ theorem.
 
 \subsection{Proof for finite-variance case}
 
-In practice, most distribution we ever come across has finite variance,
+In practice, most distributions we ever come across have finite variance,
 it may be better to give a counterexample.
 
 \begin{example}[A distribution with finite mean but infinite variance]
@@ -253,7 +253,7 @@ $|S_1|\geq a \vee |S_2| \geq a \vee \cdots$ for free!
 		\EE[S_n^2 \cdot \mathbf{1}_{A_i}]
 		&= \EE[(S_i + (S_n-S_i))^2 \cdot \mathbf{1}_{A_i}] \\
 		&= \EE[S_i^2 \cdot \mathbf{1}_{A_i}]
-		+ \EE[S_i  \cdot \mathbf{1}_{A_i} (S_n-S_i)]
+		+ 2\EE[S_i  \cdot \mathbf{1}_{A_i} (S_n-S_i)]
 		+ \EE[(S_n-S_i)^2 \cdot \mathbf{1}_{A_i}] \\
 	\end{align*}
 	The middle term $\EE[S_i  \cdot \mathbf{1}_{A_i} (S_n-S_i)]$ is $0$
@@ -360,14 +360,14 @@ The basic idea is to truncate the value of each $X_i$ so that each of them has f
 		So the complement of $A$ has measure $1$.
 		For any world $\omega \notin A$,
 		we then have
-		\[ \lim_n \left\lvert X(\omega) - X_n(\omega) \right\rvert = 1 \]
+		\[ \lim_n \left\lvert X(\omega) - X_n(\omega) \right\rvert = 0 \]
 		because when $n > N_m$ that absolute value
 		is always at most $1/m$ (as $\omega \notin A_m$).
 	\end{sol}
 \end{problem}
 
 \begin{problem}
-	[Almost sure convorgence is not topologizable]
+	[Almost sure convergence is not topologizable]
 	Consider the space of all random variables on $\Omega = [0,1]$.
 	Prove that it's impossible to impose a metric on this space
 	which makes the following statement true:

--- a/tex/measure/martingale.tex
+++ b/tex/measure/martingale.tex
@@ -4,7 +4,7 @@
 We now take our newfound knowledge of measure theory to a casino.
 
 Here's the most classical example that shows up:
-a casino lets us play a game where we can bet any amount of
+a casino lets us play a game where we can bet any amount
 on a fair coin flip, but with bad odds:
 we win $\$n$ if the coin is heads,
 but lose $\$2n$ if the coin is tails,
@@ -23,7 +23,7 @@ we actually can almost surely make a profit.
 			\ii If we win, then we leave having made $\$10-\$2=\$8$, and
 			\ii If we lose then we bet $\$100$ instead, and
 			\begin{itemize}
-				\ii If we win, we leave having made $\$1000-\$20-\$2=\$978$, and
+				\ii If we win, we leave having made $\$100-\$20-\$2=\$78$, and
 				\ii If we lose then we bet $\$1000$ instead, and so on\dots
 			\end{itemize}
 		\end{itemize}
@@ -56,7 +56,7 @@ you only know partial information about the world.
 For example, at the time of writing,
 we know that the world did not end in 2012
 (see \url{https://en.wikipedia.org/wiki/2012_phenomenon}),
-but the fate of humanity in future years remains at slightly uncertain.
+but the fate of humanity in future years remains slightly uncertain.
 
 Let's write this measure-theoretically: we could consider
 \begin{align*}
@@ -94,7 +94,7 @@ Here are some more serious examples.
 	[Examples of sub-$\sigma$-algebras]
 	\listhack
 	\begin{enumerate}[(a)]
-		\ii Let $X \colon \Omega \to \{0,1,2\}$ be a random
+		\ii Let $X \colon \Omega \to \{1,2,3\}$ be a random
 		variable taking on one of three values.
 		If we're interested in $X$ then we could define
 		\begin{align*}
@@ -105,7 +105,7 @@ Here are some more serious examples.
 		then we could write
 		\[ \SF = \left\{ \varnothing, \; A, \; B, \; C, \;
 				A \cup B, \; B \cup C, \; C \cup A, \; \Omega \right\}. \]
-		This is a sub-$\sigma$-algebra on $\SF$
+		This is a sub-$\sigma$-algebra on $\Omega$
 		that lets us ask questions about $X$
 		like ``what is the probability $X \neq 3$'', say.
 
@@ -248,11 +248,11 @@ it would be sensible for us to define random real variable $Z = \EE(X \mid Y)$ b
 \end{align*}
 
 \begin{example}
-	Let $X$ and $Y$ be the result of rolling two dices. Then:
+	Let $X$ and $Y$ be the result of rolling two dice. Then:
 	\begin{itemize}
 		\ii $\EE[X \mid X+Y = 3] = 1.5$, as you can easily calculate.
-		\ii $\EE(X \mid X+Y)$ is a random variable, which would takes the value
-		$1.5$ in any world whether $X+Y = 3$.
+		\ii $\EE(X \mid X+Y)$ is a random variable, which would take the value
+		$1.5$ in any world where $X+Y = 3$.
 		\ii More generally, we have in fact
 		\[ \EE(X \mid X+Y) = \frac{X+Y}{2}. \]
 	\end{itemize}
@@ -260,7 +260,7 @@ it would be sensible for us to define random real variable $Z = \EE(X \mid Y)$ b
 	definition.
 \end{example}
 
-Of course, as we explained earlier, this naive attempts will give us division-by-zero
+Of course, as we explained earlier, these naive attempts will give us division-by-zero
 everywhere for the continuous case --- so, enters the sub-$\sigma$-algebra.
 
 \begin{proposition}
@@ -442,7 +442,7 @@ Let's give examples.
 		Then the sequence $Y_1$, $Y_2$, \dots\ defined by
 		\[ Y_n \defeq X_1 X_2 \cdots X_n \]
 		is a martingale; as
-		$\EE(Y_n \mid Y_1, \dots, Y_{n-1}) = \EE[Y_n] \cdot Y_{n-1} = Y_{n-1}$.
+		$\EE(Y_n \mid Y_1, \dots, Y_{n-1}) = \EE[X_n] \cdot Y_{n-1} = Y_{n-1}$.
 
 		\ii \textbf{Iterated blackjack}:
 		Suppose one shows up to a casino and plays
@@ -453,7 +453,7 @@ Let's give examples.
 \end{example}
 
 \begin{example}
-	[Frivolous/inflamamtory example --- real life is a supermartingale]
+	[Frivolous/inflammatory example --- real life is a supermartingale]
 
 	Let $X_t$ be your happiness on day $t$ of your life.
 	Life has its ups and downs,
@@ -511,7 +511,7 @@ $\tau \colon \Omega \to \{0, 1, 2, \dots\} \cup \{\infty\}$ such that
 	\ii $X_{\tau \wedge n}$ is the random value representing the
 	value at time $n$ of the stopped martingale,
 	where if $n$ is \emph{after} the stopping time,
-	we just take it to be the our currently value after we leave.
+	we just take it to be our current value after we leave.
 
 	So for example in a world $\omega$ where we stopped at time $3$, then
 	$X_{\tau \wedge 0}(\omega) = X_0(\omega)$,
@@ -574,12 +574,12 @@ Here's the compiled machine code.
 	We have almost everywhere the inequalities
 	\begin{align*}
 		\EE\left( X_{\tau \wedge n} \mid \SF_{n-1} \right)
-		&= \EE \left( X_{n-1} + \mathbf 1_{\tau(\omega) = n-1} (X_n - X_{n-1}) \mid \SF_{n-1} \right) \\
-		&= \EE \left( X_{n-1} \mid \SF_{n-1} \right)
-		+ \EE \left( \mathbf 1_{\tau(\omega) = n-1} \cdot (X_n - X_{n-1}) \mid \SF_{n-1} \right) \\
-		&= X_{n-1} + \mathbf 1_{\tau(\omega) = n-1}
+		&= \EE \left( X_{\tau \wedge (n-1)} + \mathbf 1_{\tau(\omega) \ge n} (X_n - X_{n-1}) \mid \SF_{n-1} \right) \\
+		&= \EE \left( X_{\tau \wedge (n-1)} \mid \SF_{n-1} \right)
+		+ \EE \left( \mathbf 1_{\tau(\omega) \ge n} \cdot (X_n - X_{n-1}) \mid \SF_{n-1} \right) \\
+		&= X_{\tau \wedge (n-1)} + \mathbf 1_{\tau(\omega) \ge n}
 			\cdot\EE \left(  X_n - X_{n-1} \mid \SF_{n-1} \right)
-		\le X_{n-1}
+		\le X_{\tau \wedge (n-1)}
 	\end{align*}
 	as functions from $\Omega \to \RR$.
 \end{proof}
@@ -599,7 +599,7 @@ Here's the compiled machine code.
 		\ii \textbf{Finite bets}: we have $\mathbb E[\tau] < \infty$,
 		and for each $n \ge 1$, the conditional expectation
 		\[ \EE\left( \left\lvert X_n-X_{n-1} \right\rvert
-			\mid \SF_n \right) \]
+			\mid \SF_{n-1} \right) \]
 		takes on values at most $C$ for almost all $\omega \in \Omega$
 		satisfying $\tau(\omega) \ge n$.
 	\end{enumerate}
@@ -717,7 +717,7 @@ of random variables is modified to create a martingale can be found in \Cref{exe
 	\begin{itemize}
 		\ii If we define $X_1 = A_1-B_1+\frac{1}{3}$, then $\EE[X_1]=1$, so we're fine.
 		\ii Similarly, we can also define $X_1 = \frac{3}{2}\cdot(A_1-B_1)$.
-		\ii Or $X_1 = \frac{9}{4}\cdot (A_1-B_1)^2$.
+		\ii Or $X_1 = \frac{3}{4}\cdot (A_1-B_1)^2$.
 		\ii \dots\ et cetera\dots
 	\end{itemize}
 \end{example}


### PR DESCRIPTION
Proofreading pass over the **Probability** part (issue #315): `tex/measure/randvar.tex`, `tex/measure/large-laws.tex`, and `tex/measure/martingale.tex`. (`randvar.tex` needed no changes.)

Most fixes are minor (typos/grammar). A few are small calculation fixes, and two are corrections to mathematical arguments that I'd appreciate a second look at (flagged below).

### Calculation / math fixes
- **`martingale.tex` (casino example):** the winnings on the third bet were computed as `$1000 - $20 - $2 = $978`, but betting `$100` wins `$100`, so it should be `$100 - $20 - $2 = $78`.
- **`martingale.tex` (ballot example):** the third illustrative martingale `$X_1 = \frac94 (A_1-B_1)^2$` gives `\EE[X_1] = 3`, not the intended `1`. The coefficient should be `\frac34` (since `\EE[(A_1-B_1)^2] = \frac43`).
- **`martingale.tex` (product martingale):** `\EE(Y_n \mid \dots) = \EE[Y_n]\cdot Y_{n-1}` should be `\EE[X_n]\cdot Y_{n-1}` — the conditional expectation factors out the known `Y_{n-1}`, leaving `\EE[X_n] = 1`.
- **`large-laws.tex` (Kolmogorov inequality proof):** the cross term in the expansion of `(S_i + (S_n-S_i))^2` was missing its factor of `2`. (The term is `0`, so the conclusion is unaffected, but the expansion was incorrect.)
- **`large-laws.tex` ("Quantifier hell" solution):** the a.s.-convergence conclusion read `\lim_n |X-X_n| = 1`; it should be `= 0` (the surrounding argument bounds it by `1/m` for every `m`).
- **`large-laws.tex`:** added the missing `\,d\mu` to `\EE[X_i] = \int_\Omega X_i(\omega)`.

### ⚠️ Argument corrections — please review
- **`martingale.tex`, "Stopped supermartingales are still supermartingales" proof:** the increment decomposition was written as `X_{n-1} + \mathbf 1_{\tau = n-1}(X_n - X_{n-1})` bounded by `X_{n-1}`. As written this identity does not hold (e.g. when `\tau = n-1` or `\tau \ge n`). I corrected it to the standard decomposition `X_{\tau\wedge(n-1)} + \mathbf 1_{\tau \ge n}(X_n - X_{n-1}) \le X_{\tau\wedge(n-1)}`, which is what the supermartingale conclusion requires. Worth a sanity check.
- **`martingale.tex`, optional stopping "Finite bets" hypothesis:** changed the conditioning from `\SF_n` to `\SF_{n-1}` in `\EE(|X_n - X_{n-1}| \mid \SF_n)`. Conditioning on `\SF_n` makes the increment already measurable (so the conditional expectation is trivial); the standard bounded-increments hypothesis conditions on `\SF_{n-1}`.

### Typos / grammar
- "converges in probability to `$X$` **if** if for every" → removed duplicate "if".
- "most **distribution** … **has** finite variance" → "most distributions … have".
- "expected number of steps **starting** to reach 0 starting from" → removed redundant "starting".
- casino game: "bet any amount **of** on a fair coin flip" → "bet any amount on".
- "remains **at** slightly uncertain" → "remains slightly uncertain".
- example `X \colon \Omega \to \{0,1,2\}` was inconsistent with the events `X=1,2,3` defined just below → `\{1,2,3\}`.
- "This is a sub-`$\sigma$`-algebra on `$\SF$`" → "on `$\Omega$`".
- "rolling two **dices**" → "two dice"; "would **takes** the value" → "would take"; "in any world **whether** `$X+Y=3$`" → "where".
- "**this** naive attempts will give" → "these naive attempts".
- "Frivolous/**inflamamtory** example" → "inflammatory".
- "take it to be **the our currently** value" → "our current value".
- "Almost sure **convorgence** is not topologizable" → "convergence".

Closes the Probability checkbox in #315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013cZCGGkrXhnb2j2oWVYkT7)_