### PR TITLE
fix: proofread Differential Geometry part

### DIFF
--- a/tex/diffgeo/forms.tex
+++ b/tex/diffgeo/forms.tex
@@ -507,7 +507,7 @@ and extends to all of $T^k(V^\vee)$ by linearity the obvious way.
 Unlike the situation with the wedge product above, this map is indeed well-defined.
 
 With some manual work, we can check $\phi$ is injective. Because both $T^k(V^\vee)$ and
-$(T^k(V))^\vee$ has dimension $(\dim V)^k$, $\phi$ is bijective.
+$(T^k(V))^\vee$ have dimension $(\dim V)^k$, $\phi$ is bijective.
 
 Next, note that $\bigwedge^k(V)$ is just ``$T^k(V)$ but with more relations imposed'',
 there is a natural quotient map $q \colon T^k(V) \surjto \bigwedge^k(V)$.
@@ -566,7 +566,7 @@ that takes each element to the alternating tensor in $T^k(V^\vee)$.
 	With the same example as above, $V = \RR^2$, then we get
 	\[
 		\iota(\ee_1 \wedge \ee_2) = \Alt(\ee_1 \otimes \ee_2)
-		= \frac{\ee_2 \otimes \ee_1 - \ee_1 \otimes \ee_2}{2}.
+		= \frac{\ee_1 \otimes \ee_2 - \ee_2 \otimes \ee_1}{2}.
 	\]
 \end{example}
 Finally,
@@ -684,7 +684,7 @@ We write $\omega_p(v) \in \RR$.
 Since only the direction matters, it makes sense to make $\omega$ satisfy
 $\omega_p(\lambda v) = \lambda \omega_p(v)$ for $\lambda \geq 0$.  In particular, $\omega_p(0) = 0$.
 
-Then, $ds$ is the differential form $ds_p(v) = \Vert v \Vert$. While we have not rigorously defined
+Then, $ds$ is the $1$-density $ds_p(v) = \Vert v \Vert$. While we have not rigorously defined
 how to integrate over a curve (we will do this next chapter), you can intuitively see how it works.
 
 With this definition, a $1$-form is just a $1$-density that is in addition linear in the second

--- a/tex/diffgeo/manifolds.tex
+++ b/tex/diffgeo/manifolds.tex
@@ -313,7 +313,7 @@ As another example, if $M = S^1$ is a circle, there is
 no default ``clockwise'' or ``counterclockwise'' unless we decide
 to embed $M$ into $\RR^2$.
 
-To work around this we have to actually have to
+To work around this we actually have to
 make additional assumptions about our manifold.
 \begin{definition}
 	A smooth $n$-manifold is \vocab{orientable} if
@@ -325,7 +325,7 @@ Recall here that $\omega_p$ is an element of $\bigwedge^n(V^\vee)$.
 In that case we say $\omega$ is a \vocab{volume form} of $M$.
 
 How do we picture this definition?
-If we recall that an differential form is supposed to take
+If we recall that a differential form is supposed to take
 tangent vectors of $M$ and return real numbers.
 To this end, we can think of each point $p \in M$ as
 having a \vocab{tangent plane} $T_p(M)$ which is $n$-dimensional.
@@ -422,7 +422,7 @@ then the tangent vector at a point $p$
 should just look like a vector running off tangent to the circle.
 Similarly, given a sphere $M = S^2$,
 the tangent space at a point $p$ along the sphere
-would look like plane tangent to $M$ at $p$.
+would look like a plane tangent to $M$ at $p$.
 
 \begin{center}
 	\begin{asy}
@@ -451,7 +451,7 @@ rather than as embedded in $\RR^n$.\footnote{This
 	During the 19th century, a group was literally defined
 	as a subset of $\text{GL}(n)$ or of $S_n$.
 	In fact Sylow developed his theorems without the word ``group''.
-	Only much later did the abstract definition of a group was given,
+	Only much later was the abstract definition of a group given,
 	an abstract set $G$ which was independent of any \emph{embedding} into $S_n$,
 	and an object in its own right.}
 So, we would like our notion of a tangent vector to not refer to an ambient space,
@@ -538,7 +538,7 @@ but has some nice properties:
 \subsection{Sanity check}
 With all these equivalent definitions, the last thing I should do is check that
 this definition of tangent space actually gives a vector space of dimension $n$.
-To do this it suffices to show verify this for open subsets of $\RR^n$,
+To do this it suffices to verify this for open subsets of $\RR^n$,
 which will imply the result for general manifolds $M$
 (which are locally open subsets of $\RR^n$).
 Using some real analysis, one can prove the following result:

--- a/tex/diffgeo/multivar.tex
+++ b/tex/diffgeo/multivar.tex
@@ -113,7 +113,7 @@ this we use the norm of the vector space.
 \end{definition}
 
 \begin{ques}
-	Check if that $V = W = \RR$, this is equivalent to the single-variable definition.
+	Check that if $V = W = \RR$, this is equivalent to the single-variable definition.
 	(What are the linear maps from $V$ to $W$?)
 \end{ques}
 \begin{example}[Total derivative of $f(x,y) = x^2+y^2$]

--- a/tex/diffgeo/stokes.tex
+++ b/tex/diffgeo/stokes.tex
@@ -223,9 +223,9 @@ So we can now give the definition.
 	\[ \int_c \alpha \coloneqq \int_{[0,1]^k} c^\ast \alpha. \]
 \end{definition}
 Since $c^\ast \alpha$ is a $k$-form on the $k$-dimensional unit box,
-it can be written as $f(x_1, \dots, x_n) \; dx_1 \wedge \dots \wedge dx_n$,
+it can be written as $f(x_1, \dots, x_k) \; dx_1 \wedge \dots \wedge dx_k$,
 So the above integral could also be written as
-\[ \int_0^1 \dots \int_0^1 f(x_1, \dots, x_n) \; dx_1 \wedge \dots \wedge dx_n. \]
+\[ \int_0^1 \dots \int_0^1 f(x_1, \dots, x_k) \; dx_1 \wedge \dots \wedge dx_k. \]
 
 \begin{example}[Area of a circle]
 	Consider $V = \RR^2$ and let $c \colon (r,\theta) \mapsto (r\cos\theta)\ee_1 + (r\sin\theta)\ee_2$
@@ -306,7 +306,7 @@ First, I introduce a technical term that lets us consider multiple cells at once
 	i.e.\ a sum of the form
 	\[ c = a_1 c_1 + \dots + a_m c_m \]
 	where each $a_i \in \RR$ and $c_i$ is a $k$-cell.
-	We define $\int_c \alpha = \sum_i a_i \int c_i$.
+	We define $\int_c \alpha = \sum_i a_i \int_{c_i} \alpha$.
 \end{definition}
 In particular, a $0$-chain consists of several points, each with a given weight.
 
@@ -369,7 +369,7 @@ Here's how we do it in general.
 			label("$c$", (p1+p2+p3+p4)/4);
 		\end{asy}
 	\end{center}
-	Here $p_1$, $p_2$, $p_3$, $p_4$ are the images of $(0,0)$, $(0,1)$, $(1,1)$, $(1,0)$, respectively.
+	Here $p_1$, $p_2$, $p_3$, $p_4$ are the images of $(0,0)$, $(1,0)$, $(1,1)$, $(0,1)$, respectively.
 	Formally, $\partial c$ is given by
 	\[ \partial c = (t \mapsto c(1,t)) - (t \mapsto c(0,t))
 		- (t \mapsto c(t,1)) + (t \mapsto c(t,0)). \]
@@ -648,7 +648,7 @@ we know it's possible to integrate an $n$-form in $\RR^n$ and get a number. That
 	\ii An area integral $\int_{a_1}^{b_1} \int_{a_2}^{b_2} f(x,y) \odif x \odif y$
 	corresponds to integrating the $2$-form $f \cdot \ee_1^\vee \wedge \ee_2^\vee$.
 
-	\ii A volume integral $\int_{a_1}^{b_1} \int_{a_2}^{b_2} \int_{a_3}^{b_3} f(x,y) \odif x \odif y \odif z$
+	\ii A volume integral $\int_{a_1}^{b_1} \int_{a_2}^{b_2} \int_{a_3}^{b_3} f(x,y,z) \odif x \odif y \odif z$
 	corresponds to integrating the $3$-form $f \cdot \ee_1^\vee \wedge \ee_2^\vee \wedge \ee_3^\vee$.
 \end{itemize}
 So this takes care of the green-labeled things on the diagonal.
@@ -718,10 +718,10 @@ However, the three purplish integrals (over vector fields) can be viewed in our 
 	the definition of cross products taught in school is
 	\[ \mathbf{v} \times \mathbf{w} \coloneqq (yz'-y'z) \ee_1 + (zx'-xz') \ee_2 + (xy'-x'y) \ee_3. \]
 	Where does this come from?
-	The answer is that $\star(\mathbf{v} \vee \mathbf{w})$:
+	The answer is that $\star(\mathbf{v} \wedge \mathbf{w})$:
 	\begin{align*}
 		\mathbf{v} \wedge \mathbf{w} &=
-		(x \ee_1 + y \ee_2 + z \ee_3) \times (x' \ee_1 + y' \ee_2 + z' \ee_3) \\
+		(x \ee_1 + y \ee_2 + z \ee_3) \wedge (x' \ee_1 + y' \ee_2 + z' \ee_3) \\
 		&= (xy'-x'y) \ee_1 \wedge \ee_2
 		+ (yz'-y'z) \ee_2 \wedge \ee_3
 		+ (zx'-xz') \ee_3 \wedge \ee_1 \\
@@ -843,7 +843,7 @@ because we get six 18.02 theorems as special cases!
 	Show that $\partial^2 = 0$.
 	\label{prob:partial_zero}
 	\begin{hint}
-		This is just an exercises in sigma notation.
+		This is just an exercise in sigma notation.
 	\end{hint}
 \end{problem}
 


### PR DESCRIPTION
This proofreads the **Differential Geometry** part (issue #315), covering `tex/diffgeo/multivar.tex`, `forms.tex`, `stokes.tex`, and `manifolds.tex`. All findings are minor: typos, grammar, and small notation/calculation slips.

## `multivar.tex`
- Fixed swapped words in an exercise: "Check **if that** $V=W=\RR$" → "Check **that if** $V=W=\RR$".

## `forms.tex`
- Subject–verb agreement: "both … **has** dimension" → "**have**".
- **Sign fix** in the `\Alt` example: line gave $\Alt(\ee_1\otimes\ee_2)=\frac{\ee_2\otimes\ee_1-\ee_1\otimes\ee_2}{2}$, which is the negative of the definition (and of the earlier example on the same page). Corrected to $\frac{\ee_1\otimes\ee_2-\ee_2\otimes\ee_1}{2}$.
- Terminology: "$ds$ is the **differential form** …" → "$ds$ is the **$1$-density** …", since the entire section argues that $ds$ is *not* a differential form.

## `stokes.tex`
- Index fix: $c^\ast\alpha$ on the $k$-dimensional box was written with coordinates $x_1,\dots,x_n$ / $dx_n$; changed to $x_1,\dots,x_k$ / $dx_k$.
- Chain-integral definition: $\int_c\alpha=\sum_i a_i\int c_i$ → $\sum_i a_i\int_{c_i}\alpha$.
- Corner labels of the $2$-cell boundary example: the images were listed as $(0,0),(0,1),(1,1),(1,0)$, which disagrees with the picture and with the $\partial c$ formula immediately below; corrected to $(0,0),(1,0),(1,1),(0,1)$.
- Volume integral integrand $f(x,y)$ → $f(x,y,z)$.
- Cross-product derivation: $\star(\mathbf v \vee \mathbf w)$ → $\star(\mathbf v \wedge \mathbf w)$, and a stray $\times$ → $\wedge$ on the RHS of the $\mathbf v\wedge\mathbf w$ expansion.
- "an **exercises** in sigma notation" → "an **exercise**".

## `manifolds.tex`
- Grammar: doubled "we **have to** actually **have to**" → "we actually have to"; "**an** differential form" → "a"; "look like **plane** tangent" → "a plane tangent"; "Only much later **did** the abstract definition of a group **was given**" → "was … given"; "it suffices to **show verify** this" → "to verify this".

No large mathematical errors were found in this part.

Part of the proofreading campaign (#315).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYU47Lb6GPLngK4HjC1a67)_