### PR TITLE
fix: proofread Galois and Ramification Theory part

### DIFF
--- a/tex/alg-NT/artin.tex
+++ b/tex/alg-NT/artin.tex
@@ -331,7 +331,7 @@ Recall some examples from \Cref{ex:frob_gaussian_integers} and \Cref{lem:cyclo_f
 
 	Then it follows just like before that
 	if $p \nmid m$ is prime and $\kP$ is above $p$
-	\[ \Frob_\kP(x) = \sigma_p. \]
+	\[ \Frob_\kP = \sigma_p. \]
 \end{example}
 
 Here, as hinted in \Cref{sec:more_general_extensions}, we have to generalize the
@@ -425,7 +425,7 @@ To see why:
 		\left( \frac{K(\cbrt 2)/K}{\theta \OO_K} \right) \left( \cbrt 2 \right)
 		\equiv \left( \cbrt 2 \right)^{\Norm(\theta)}
 		\equiv 2^{\frac{\Norm(\theta)-1}{3}} \cdot \cbrt 2
-		\equiv \left( \frac{2}{\theta} \right)_3 \cbrt 2.
+		\equiv \left( \frac{2}{\theta} \right)_3 \cbrt 2
 		\pmod{\kP}
 	\]
 	where $\kP$ is above $(\theta)$ in $K(\cbrt 2)$.
@@ -594,7 +594,7 @@ corresponds to a field extension.
 
 (Of course, the question of how to compute the field $L$ given a modulus and a congruence subgroup
 is still difficult. At least when $K = \QQ$, \Cref{prob:kronecker_weber_theorem} gives the answer:
-all finite abelian field extensions $L/\QQ$ are contained in some cyclotomic field.
+all finite abelian field extensions $L/\QQ$ are contained in some cyclotomic field.)
 
 \bigskip
 
@@ -730,7 +730,7 @@ We will see one more example below.
 
 	Consider abelian field extensions $L/\QQ$. Let the modulus in $\QQ$ be $\km = 15 \infty$.
 
-	The ray class group $C_K(\km)$ is of course isomorphic to $\Zm{15} \cong \Zm{3} \times \Zm{5}
+	The ray class group $C_\QQ(\km)$ is of course isomorphic to $\Zm{15} \cong \Zm{3} \times \Zm{5}
 	\cong \Zc{2} \times \Zc{4}$.
 
 	As small as this group is (with only 8 elements), it has 8 subgroups.%
@@ -765,18 +765,18 @@ We will see one more example below.
 	value mod $5 \infty$. Formally, we have this diagram:
 	\begin{center}
 	\begin{tikzcd}
-		P_K(15 \infty) \ar[d, hook] \ar[r, hook] &
-		I_K(15 \infty) \ar[d, hook] \ar[r, surjective head] &
-		C_K(15 \infty) \ar[d, surjective head] \\
-		P_K(5 \infty) \ar[r, hook] &
-		I_K(5 \infty) \ar[r, surjective head] &
-		C_K(5 \infty)
+		P_\QQ(15 \infty) \ar[d, hook] \ar[r, hook] &
+		I_\QQ(15 \infty) \ar[d, hook] \ar[r, surjective head] &
+		C_\QQ(15 \infty) \ar[d, surjective head] \\
+		P_\QQ(5 \infty) \ar[r, hook] &
+		I_\QQ(5 \infty) \ar[r, surjective head] &
+		C_\QQ(5 \infty)
 	\end{tikzcd}
 	\end{center}
 	(If you have read the category theory chapter:
 	Morphism of short exact sequence appears everywhere! You just have to look for it.)
 
-	That is, we get an induced $C_K(15 \infty) \surjto C_K(5 \infty)$ map,
+	That is, we get an induced $C_\QQ(15 \infty) \surjto C_\QQ(5 \infty)$ map,
 	or equivalently, $\Zm{15} \surjto \Zm{5}$.
 	This time around, the abelian field extensions that corresponds to the modulus $5 \infty$ are:
 	\begin{center}
@@ -797,7 +797,7 @@ Let $L = K(i)$. (Later on, we will know that $L$ is the \vocab{Hilbert class fie
 We claim the following is true:
 \begin{itemize}
 	\ii $L/K$ is an abelian extension,
-	\ii the discriminant is $\kf = \kf(L/K) = 1$,
+	\ii the conductor is $\kf = \kf(L/K) = 1$,
 	\ii $H(L/K, \kf) = P_K(\kf)$ --- that is, this is exactly the situation where we can determine
 	$\kp \pmod{1}$ for $\kp \subseteq K$ based on $\left(\frac{L/K}{\kp}\right)$.
 \end{itemize}
@@ -832,7 +832,7 @@ Hilbert class field of $\QQ$ --- but, by Artin reciprocity, we do know:
 \begin{moral}
 	The value of $\left(\frac{L/\QQ}{(p)}\right)$ only depends on $(p) \pmod{\kf(L/\QQ)}$.
 \end{moral}
-In this case, the discriminant of the extension $L/\QQ$ is $\kf(L/\QQ) = 20 \infty$.
+In this case, the conductor of the extension $L/\QQ$ is $\kf(L/\QQ) = 20 \infty$.
 
 So, in summary:
 \begin{align*}
@@ -857,7 +857,7 @@ We're done! The final form of the theorem is:
 	\label{prob:kronecker_weber_theorem}
 	[Kronecker-Weber theorem]
 	Let $L$ be an abelian extension of $\QQ$.
-	Then $L$ is contained in a cyclic extension $\QQ(\zeta)$
+	Then $L$ is contained in a cyclotomic extension $\QQ(\zeta)$
 	where $\zeta$ is an $m$th root of unity (for some $m$).
 	\begin{hint}
 		Pick $m$ so that $\kf(L/\QQ) \mid m\infty$.
@@ -866,7 +866,7 @@ We're done! The final form of the theorem is:
 		Suppose $\kf(L/\QQ) \mid m\infty$ for some $m$.
 		Then by the example from earlier we have the chain
 		\[ P_{\QQ}(m\infty) = H(\QQ(\zeta)/\QQ, m\infty)
-			\subseteq H(L/\QQ, m) \subseteq I_\QQ(m\infty). \]
+			\subseteq H(L/\QQ, m\infty) \subseteq I_\QQ(m\infty). \]
 		So by inclusion reversal we're done.
 	\end{sol}
 \end{dproblem}
@@ -898,9 +898,9 @@ We're done! The final form of the theorem is:
 			with this property has conductor $1$ (no primes divide the conductor),
 			and then we have $P_K(1) = H(E/K, 1) \subseteq H(M/K, 1) \subseteq I_K(1)$,
 			so inclusion reversal gives $M \subseteq E$.
-			\ii We have $\Gal(L/K) \cong I_K(1) / P_K(1) = C_K(1)$ the class group.
+			\ii We have $\Gal(E/K) \cong I_K(1) / P_K(1) = C_K(1)$ the class group.
 			\ii The isomorphism in the previous part is given by the Artin symbol.
-			So $\kp$ splits completely if and only if $\left( \frac{L/K}{\kp} \right) = \id$
+			So $\kp$ splits completely if and only if $\left( \frac{E/K}{\kp} \right) = \id$
 			if and only if $\kp$ is principal (trivial in $C_K(1)$).
 		\end{itemize}
 		This completes the proof.

--- a/tex/alg-NT/finite-field.tex
+++ b/tex/alg-NT/finite-field.tex
@@ -249,9 +249,9 @@ in the following chapters.
 
 Consider the field $F$ of order $p = 17$. We may want to ask the following questions about $F$:
 \begin{itemize}
-	\ii How many nonzero elements in $F$ is a quadratic residue (can be written as a square of
+	\ii How many nonzero elements in $F$ are quadratic residues (can be written as a square of
 	another element in $F$)?
-	\ii Is there any element $x$ in $p$ such that $x^2 = -1$?
+	\ii Is there any element $x$ in $F$ such that $x^2 = -1$?
 \end{itemize}
 
 With the following proposition, the questions above become easy.
@@ -298,7 +298,7 @@ in particular finitely generated, and can be written in the form
 	\dots \oplus \Zc{q_m}.  \]
 Of course, $r = 0$ here.
 
-Now, assume $F^\times$ is not cyclic, so the lowest common denominator of all the $q_i$ values are
+Now, assume $F^\times$ is not cyclic, so the least common multiple of all the $q_i$ values is
 less than $|F^\times|$.
 Then, for all $x \in F^\times$, $x^{\lcm(q_1, \dots, q_m)} = 1$, which gives a contradiction.
 
@@ -325,7 +325,7 @@ Then, for all $x \in F^\times$, $x^{\lcm(q_1, \dots, q_m)} = 1$, which gives a c
 	Show the polynomial $P(X)$ is irreducible modulo $127$;
 	then work in the splitting field of $P$, namely $\FF_{p^2}$.
 
-	Show that $\FF_p=-1$, $\FF_{p+1}=0$, $\FF_{2p+1}=1$, $\FF_{2p+2}=0$.
+	Show that $F_p=-1$, $F_{p+1}=0$, $F_{2p+1}=1$, $F_{2p+2}=0$.
 	(Look at the action of $\Gal(\FF_{p^2}/\FF_p)$
 	on the roots of $P$.)
 	\end{hint}

--- a/tex/alg-NT/frobenius.tex
+++ b/tex/alg-NT/frobenius.tex
@@ -21,7 +21,7 @@ Surprisingly, it is nevertheless possible to extend this to some field automorph
 
 If $p$ is unramified, then one can show there
 is a unique $\sigma \in \Gal(K/\QQ)$ such that
-$\sigma(\alpha) \equiv \alpha^p \pmod{\kp}$ for every prime $p$.
+$\sigma(\alpha) \equiv \alpha^p \pmod{\kp}$ for every $\alpha \in \OO_K$.
 
 \section{Frobenius elements}
 \prototype{$\Frob_\kp$ in $\ZZ[i]$ depends on $p \pmod 4$.}
@@ -207,7 +207,7 @@ really just comes from the more friendly-looking rational prime $p$.
 		\cong S_3.  \]
 	In this $S_3$ there are $3$ elements of order two:
 	fixing one root and swapping the other two.
-	These correspond to each of $\Frob_{\kp_1}$, $\Frob{\kp_2}$, $\Frob_{\kp_3}$.
+	These correspond to each of $\Frob_{\kp_1}$, $\Frob_{\kp_2}$, $\Frob_{\kp_3}$.
 
 	In conclusion, the conjugacy class
 	$\left\{ \Frob_{\kp_1}, \Frob_{\kp_2}, \Frob_{\kp_3} \right\}$
@@ -785,7 +785,7 @@ such that $X^p-p$ is irreducible modulo $q$.
 		Chebotarev Density on $\QQ(\zeta_m)$.
 	\end{hint}
 	\begin{sol}
-		Let $K = \Gal(\QQ(\zeta_m)/\QQ)$.
+		Let $K = \QQ(\zeta_m)$.
 		One can show that $\Gal(K/\QQ) \cong \Zm m$ exactly as before.
 		In particular, $\Gal(K/\QQ)$ is abelian and therefore its conjugacy classes
 		are singleton sets; there are $\phi(m)$ of them.

--- a/tex/alg-NT/galois.tex
+++ b/tex/alg-NT/galois.tex
@@ -176,7 +176,7 @@ Now that I've defined all these ingredients, I can prove:
 	Recall that any irreducible polynomial over $\QQ$ has distinct roots (\Cref{lem:irred_complex}).
 	We'll adjoin elements $\alpha_1, \alpha_2, \dots, \alpha_m$ one at a time to $\QQ$,
 	until we eventually get all of $K$, that is,
-	\[ K = \QQ(\alpha_1, \dots, \alpha_n). \]
+	\[ K = \QQ(\alpha_1, \dots, \alpha_m). \]
 	Diagrammatically, this is
 	\begin{center}
 	\begin{tikzcd}
@@ -473,7 +473,7 @@ and call this the \vocab{Galois group} of $K/F$.
 		since it's the splitting field of $x^2-2$ over $\QQ$.
 		The Galois group has order two, $\sqrt 2 \mapsto \pm \sqrt 2$.
 		\ii The extension $\QQ(\sqrt2, \sqrt 3) / \QQ$ is Galois,
-		since it's the splitting field of $(x^2-5)^2-6$ over $\QQ$.
+		since it's the splitting field of $(x^2-5)^2-24$ over $\QQ$.
 		As discussed before, the Galois group is $\Zc 2 \times \Zc 2$.
 		\ii The extension $\QQ(\cbrt{2}) / \QQ$ is \emph{not} Galois.
 	\end{enumerate}

--- a/tex/alg-NT/ramification.tex
+++ b/tex/alg-NT/ramification.tex
@@ -180,10 +180,10 @@ In other words,
 Before proving this, let us consider the easier problem
 of factorization into elements.
 \begin{quote}
-	Suppose $\OO_K$ is an UFD, and $p$ factors as $u p_1 p_2 \cdots p_n$ in
-	$\OO_K$, where $p_i$ are irreducibles and $u$ is an unit.
+	Suppose $\OO_K$ is a UFD, and $p$ factors as $u p_1 p_2 \cdots p_n$ in
+	$\OO_K$, where $p_i$ are irreducibles and $u$ is a unit.
 	Show that the $p_i$ are all conjugates of each other, up to
-	multiplication by an unit.
+	multiplication by a unit.
 \end{quote}
 \begin{ques}
 	Try to prove it before reading it below.
@@ -197,7 +197,7 @@ of factorization into elements.
 
 Unfortunately, the product of all conjugates of an ideal $\kp_1$ is not
 necessarily of the form $p \cdot \OO_K$ (for example, $K=\QQ[i]$ and $(1+i)$
-has no other conjugates). So in the proof, we pick $x$ which is an
+has no other conjugates). So in the proof, we pick $x$ which is a
 ``representative'' of $\kp_1$.
 
 \begin{proof}
@@ -441,7 +441,7 @@ we just have $K^I = K$.
 	$x^3-2$ over $\QQ$. The rational prime $p = (5)$ splits as $p = \kp_1 \kp_2 \kp_3$ in $K$, and
 	each has inertial degree $2$. Thus $|D_{\kp_i}| = 2$ for each $i$.
 
-	We know that $\Gal(K/\QQ) \cong S_3$, and $S_3$ has no subgroups of order $2$, so obviously
+	We know that $\Gal(K/\QQ) \cong S_3$, and $S_3$ has no normal subgroups of order $2$, so obviously
 	$D_{\kp_i}$ is not normal in $G$!
 
 	As mentioned above, what happens here is: when $p$ is lifted to $K^{D_{\kp_1}}$, it splits into
@@ -453,7 +453,7 @@ we just have $K^I = K$.
 \section{Tangential remark: more general Galois extensions}
 \label{sec:more_general_extensions}
 All the discussion about Galois extensions
-carries over if we replace $K/\QQ$ by some different Galois extension $K/F$.
+carries over if we replace $K/\QQ$ by some different Galois extension $L/F$.
 Instead of a rational prime $p$ breaking down in $\OO_K$,
 we would have a prime ideal $\kp$ of $F$ breaking down as
 \[ \kp \cdot \OO_L = (\kP_1 \dots \kP_g)^e \]


### PR DESCRIPTION
This proofreads the **Algebraic NT II: Galois and Ramification Theory** part (`tex/alg-NT/{galois,finite-field,ramification,frobenius,artin}.tex`), corresponding to issue #315.

Most fixes are minor (typos, grammar, notation slips). A few are small but genuine mathematical/terminology errors, called out below.

## Notable corrections

- **`galois.tex`** — The extension $\QQ(\sqrt2,\sqrt3)/\QQ$ was stated to be the splitting field of $(x^2-5)^2-6$. The minimal polynomial of $\sqrt2+\sqrt3$ is $(x^2-5)^2-24 = x^4-10x^2+1$ (since $(\sqrt2+\sqrt3)^2 = 5+2\sqrt6$). With $-6$ the roots are $\pm\sqrt{5\pm\sqrt6}$, generating a different field. Fixed $-6 \to -24$.
- **`ramification.tex`** — "$S_3$ has no subgroups of order $2$" is false ($S_3$ has three, generated by transpositions) and also contradicts the just-established $|D_{\kp_i}|=2$. The intended (and logically needed) statement is that $S_3$ has no *normal* subgroups of order 2. Fixed.
- **`artin.tex`** — Kronecker–Weber was stated as "$L$ is contained in a **cyclic** extension $\QQ(\zeta)$"; cyclotomic extensions are abelian but not generally cyclic (e.g. $\QQ(\zeta_8)$). Changed "cyclic" → "cyclotomic".
- **`artin.tex`** — Two places call the conductor $\kf$ the "discriminant"; the book reserves $\kf$ for the conductor (and even contrasts the two). Changed "discriminant" → "conductor".

## Minor typos / grammar / notation

- `galois.tex`: `$\QQ(\alpha_1,\dots,\alpha_n)$` → `\alpha_m` (matches the $\alpha_1,\dots,\alpha_m$ tower and $\tau_m$ in the diagram).
- `finite-field.tex`: Fibonacci numbers in a hint were typeset as `\FF_p,\FF_{p+1},\dots` (field notation) instead of `F_p,F_{p+1},\dots`; "lowest common denominator" → "least common multiple" (the next line uses `\lcm`); "elements ... is a quadratic residue" → "are quadratic residues"; "element $x$ in $p$" → "in $F$".
- `frobenius.tex`: "for every prime $p$" → "for every $\alpha \in \OO_K$" ($p$ is already fixed); missing subscript `\Frob{\kp_2}` → `\Frob_{\kp_2}`; `Let $K = \Gal(\QQ(\zeta_m)/\QQ)$` → `Let $K = \QQ(\zeta_m)$` (then $\Gal(K/\QQ)$ makes sense).
- `ramification.tex`: `$K/F$` → `$L/F$` in the general-extension remark (the surrounding text uses $\OO_L$ and "primes in $L$"); several "an unit"/"an UFD"/"an representative" → "a".
- `artin.tex`: stray `\Frob_\kP(x)` → `\Frob_\kP`; stray period inside a display; missing closing parenthesis; `C_K` → `C_\QQ` (and $P_K,I_K$) in a worked example whose base field is $\QQ$; `H(L/\QQ, m)` → `H(L/\QQ, m\infty)`; `\Gal(L/K)`/`L/K` → `E/K` in the Hilbert class field solution (the field is named $E$).

No large arguments were rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnhfNnwcsW5a9fNqNDPnu9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnhfNnwcsW5a9fNqNDPnu9)_