### PR TITLE
fix: proofread Category Theory part

### DIFF
--- a/tex/cats/abelian.tex
+++ b/tex/cats/abelian.tex
@@ -43,7 +43,7 @@ We can now define:
 	By \Cref{prob:equalizer_monic}, $\ker f$ is a monic morphism,
 	which justifies the use of ``$\injto$''.
 \end{definition}
-Notice that we're using $\ker f$ to represent the map and $\Ker f$ to represent the object
+Notice that we're using $\ker f$ to represent the map and $\Ker f$ to represent the object.
 Similarly, we define the cokernel, the dual notion:
 \begin{definition}
 	Consider a map $A \taking f B$.
@@ -220,7 +220,7 @@ We say the entire sequence is exact if it's exact at $k=1,\dots,n-1$.
 \end{example}
 
 If you look at the prototypical example, actually, a \vocab{short exact sequence} (an exact sequence
-of the form $0 \to A \to B \to C \to 0$) is the most natural things ever:
+of the form $0 \to A \to B \to C \to 0$) is the most natural thing ever:
 \begin{moral}
 	It's basically just an equation $C = B/A$.
 \end{moral}
@@ -341,7 +341,7 @@ For example, let's prove:
 	using the concrete interpretation of our category as $R$-modules.
 
 	Let $b'$ be an element of $B'$.
-	Then $q'(b') \in C'$, and since $\gamma$ is surjective, we have a $c$ such that $\gamma(c) = c'$,
+	Then $c' \defeq q'(b') \in C'$, and since $\gamma$ is surjective, we have a $c$ such that $\gamma(c) = c'$,
 	and finally a $b \in B$ such that $q(b) = c$.
 	Picture:
 	\begin{center}
@@ -370,7 +370,7 @@ For example, let's prove:
 		= \beta b + (b' - \beta b)
 		= b'
 	\]
-	so $b' \in \Img \beta$ which completes the proof that $\beta'$ is surjective.
+	so $b' \in \Img \beta$ which completes the proof that $\beta$ is surjective.
 \end{proof}
 
 In general, proofs in the style above (whether or not they use the embedding theorem)
@@ -456,7 +456,7 @@ where $C_k = \img f_{k-1} = \ker f_k$ for every $k$.
 			so if we let $b' = \beta(b)$,
 			then $b' \in \ker(q')$.
 			As the bottom row is exact, there exists $a'$ with $p'(a') = b'$.
-			\ii Since $\alpha$ is injective,
+			\ii Since $\alpha$ is surjective,
 			there is $a \in A$ with $\alpha(a) = a'$.
 			\ii Since $\beta$ is injective,
 			it follows that $p(a) = b$.

--- a/tex/cats/categories.tex
+++ b/tex/cats/categories.tex
@@ -178,7 +178,7 @@ like $\catname{Grp}$, $\catname{Top}$, or $\catname{CRing}$.
 
 Here's a second quite important example of a non-concrete category.
 \begin{example}
-	[Important: groups are one-Object categories]
+	[Important: groups are one-object categories]
 	A group $G$ can be interpreted as a category $\mathcal G$ with one object $\ast$,
 	all of whose arrows are isomorphisms.
 
@@ -359,7 +359,7 @@ $A \taking f X \times Y$.
 
 But $X \times Y$ is special in that it is ``universal'':
 for \emph{any} set $A$, if you give me functions $A \to X$ and $A \to Y$, I can use it
-build a \emph{unique} function $A \to X \times Y$.
+to build a \emph{unique} function $A \to X \times Y$.
 Picture:
 \begin{center}
 \begin{tikzcd}

--- a/tex/cats/functors.tex
+++ b/tex/cats/functors.tex
@@ -34,7 +34,7 @@ Don't worry about those for now; you'll see why in a moment.)
 		obtain a set $\Hom_{\AA}(A_1, A_2)$.
 		This turns out to be a functor $\AA\op \times \AA \to \catname{Set}$.
 		\ii The above operation has two ``slots''.
-		If we ``pre-fill'' the first slots, then we get a functor $\AA \to \catname{Set}$.
+		If we ``pre-fill'' the first slot, then we get a functor $\AA \to \catname{Set}$.
 		That is, by fixing $A \in \AA$, we obtain a functor (called $H^A$)
 		from $\AA \to \catname{Set}$ by sending $A' \in \AA$ to $\Hom_{\AA} (A, A')$.
 		This is called the covariant Yoneda functor (explained later).
@@ -99,7 +99,7 @@ and so we can now think about maps between categories.
 
 So the idea is:
 \begin{moral}
-Whenever we naturally make an object $A \in \AA$ into an object of $B \in \BB$,
+Whenever we naturally make an object $A \in \AA$ into an object $B \in \BB$,
 there should usually be a natural way to transform a map $A_1 \to A_2$ into a map $B_1 \to B_2$.
 \end{moral}
 Let's see some examples of this.
@@ -186,12 +186,12 @@ skip it and come back after reading about its contravariant version.
 
 	Now we want to specify how $H^A$ behaves on arrows.
 	For each arrow $A_1 \taking{f} A_2$, we need
-	to specify $\catname{Set}$-map $\Hom_\AA (A, A_1) \to \Hom(A, A_2)$;
+	to specify a $\catname{Set}$-map $\Hom_\AA (A, A_1) \to \Hom(A, A_2)$;
 	in other words, we need to send an arrow $A \taking{p} A_1$ to an arrow $A \to A_2$.
 	There's only one reasonable way to do this: take the composition
 	\[ A \taking{p} A_1 \taking{f} A_2. \]
-	In other words, $H_A(f)$ is $p \mapsto f \circ p$.
-	In still other words, $H_A(f) = f \circ -$;
+	In other words, $H^A(f)$ is $p \mapsto f \circ p$.
+	In still other words, $H^A(f) = f \circ -$;
 	the $-$ is a slot for the input to go into.
 \end{example}
 
@@ -254,12 +254,12 @@ spaces have isomorphic fundamental groups.
 
 \section{Covariant functors as indexed family of objects}
 
-Instead of viewing functor as a \emph{function}, sometimes it is more convenient to view a functor
+Instead of viewing a functor as a \emph{function}, sometimes it is more convenient to view a functor
 as an \emph{object} (or a family of objects).
 
 For sets $A$ and $B$, sometimes the notation $A^B$ is used to denote the set $\Hom(B, A)$ being the
 set of all functions from $B$ to $A$.
-This notation is natural because, for finite sets $A$ and $B$, then $|\Hom(B, A)|=|A|^{|B|}$.
+This notation is natural because, for finite sets $A$ and $B$, we have $|\Hom(B, A)|=|A|^{|B|}$.
 
 That said, the product set $A \times A$ is sometimes also denoted $A^2$. Is there a relation?
 
@@ -290,7 +290,7 @@ so $f$ should be a functor!
 
 So we can make a category $\catname{2}$, and we have $F \colon \catname{2}\to \AA$.
 There is only one reasonable way to define $\catname{2}$
-that do what we want:\footnote{This is \textbf{different} from the category $\textbf{2}$ that we
+that does what we want:\footnote{This is \textbf{different} from the category $\textbf{2}$ that we
 will define later for natural transformation! Be careful.}
 \begin{itemize}
 	\ii The objects are $\{ 0, 1 \}$;

--- a/tex/cats/limits.tex
+++ b/tex/cats/limits.tex
@@ -4,7 +4,7 @@ We saw near the start of our category theory chapter
 the nice construction of products by drawing
 a bunch of arrows.
 It turns out that this concept can be generalized immensely,
-and I want to give a you taste of that here.
+and I want to give you a taste of that here.
 
 To run this chapter, we follow the approach of \cite{ref:msci}.
 \todo{write introduction}
@@ -71,7 +71,7 @@ But when they do exist:
 
 		\ii In particular, given a homomorphism $\phi \colon G \to H$, the inclusion
 		$ \ker\phi \injto G $
-		is an equalizer for $\phi \colon G \to H$ and the trivial homorphism $G \to H$.
+		is an equalizer for $\phi \colon G \to H$ and the trivial homomorphism $G \to H$.
 	\end{enumerate}
 \end{example}
 
@@ -90,7 +90,7 @@ Great example: differentiable functions on $(-3,1)$ and $(-1,3)$
 
 \section{Limits}
 We've defined cones over discrete sets of $X_i$ (to get products)
-and over pairs of errors (to get forks).
+and over pairs of arrows (to get forks).
 It turns out you can also define a cone over any general \vocab{diagram} of objects and arrows;
 we specify a projection from $A$ to each object and
 require that the projections from $A$ commute with the arrows in the diagram.


### PR DESCRIPTION
Proofreads the **Category Theory** part (issue #315), covering the chapters `tex/cats/categories.tex`, `tex/cats/functors.tex`, `tex/cats/limits.tex`, and `tex/cats/abelian.tex`.

Most fixes are minor typos and grammar. A couple are small notation/logic slips worth calling out:

### Notation / correctness
- **`functors.tex`** — In the covariant Yoneda functor example, the action on arrows was written as `H_A(f)` (subscript, the *contravariant* Yoneda functor) instead of `H^A(f)` (superscript), which is the functor actually being defined there.
- **`abelian.tex`, four lemma solution** — When lifting `a'` to `a ∈ A` with `α(a) = a'`, the justification read "Since `α` is injective"; existence of such an `a` uses that **`α` is surjective (epic)**, which is what the hypothesis actually provides. Fixed the word.
- **`abelian.tex`, short five lemma proof** — The symbol `c'` was used before being defined; now set `c' ≔ q'(b')` explicitly. Also fixed a stray `β'` (no such map in the diagram) to `β`.

### Typos / grammar
- `categories.tex`: "one-Object" → "one-object"; "I can use it build" → "use it to build".
- `functors.tex`: "the first slots" → "the first slot"; "an object of `B`" → "an object `B`"; "specify `Set`-map" → "specify a `Set`-map"; "viewing functor" → "viewing a functor"; "because, ... then" → "because, ... we have"; "that do what we want" → "that does".
- `limits.tex`: "give a you taste" → "give you a taste"; "homorphism" → "homomorphism"; "pairs of errors" → "pairs of arrows".
- `abelian.tex`: "the most natural things ever" → "thing"; added a missing period.

No large mathematical errors were found; the arguments in these chapters check out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgyfoveJybAdVwGSWvYEww

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgyfoveJybAdVwGSWvYEww)_