### PR TITLE
fix: proofread Algebraic Geometry II: Affine Schemes part

### DIFF
--- a/tex/alg-geom/localization.tex
+++ b/tex/alg-geom/localization.tex
@@ -18,7 +18,7 @@ and the like.
 The point is that we introduced a lot of denominators.
 Localization will give us a concise way of doing this in general.
 
-This thus also explain why the operation is called ``localization'':
+This thus also explains why the operation is called ``localization'':
 we start from a set of ``global'' functions, and get a (larger) set of functions
 that are well-defined on a ``smaller'' open set, or in an open neighborhood
 of point $p$.
@@ -284,7 +284,7 @@ Consequently, we give several examples in this vein.
 	\begin{enumerate}[(a)]
 		\ii We let $\km$ be the maximal ideal $(x)$ of $A = \CC[x]$.
 		Then \[ A_\km = \left\{ \frac{f(x)}{g(x)} \mid g(0) \neq 0 \right\} \]
-		consists of the Laurent series.
+		consists of the rational functions with no pole at the origin.
 
 		\ii We let $\km$ be the maximal ideal $(x,y)$ of $A = \CC[x,y]$.
 		Then \[ A_\km = \left\{ \frac{f(x,y)}{g(x,y)} \mid g(0,0) \neq 0 \right\}. \]
@@ -538,7 +538,7 @@ But there are two things wrong with this:
 \begin{itemize}
 \ii The main one is that $I$ is not an ideal of $S\inv A$, as we saw above.
 This is remedied by instead using $S\inv I$,
-which consists of those elements of those elements $\frac xs$
+which consists of those elements $\frac xs$
 for $x \in I$ and $s \in S$.
 As we saw this distinction is usually masked in practice,
 because we will usually write $I = (a_1, \dots, a_n) \subseteq A$

--- a/tex/alg-geom/mor-scheme.tex
+++ b/tex/alg-geom/mor-scheme.tex
@@ -9,7 +9,7 @@ of arbitrary locally ringed spaces.
 
 \section{Morphisms of ringed spaces via sections}
 Let $(X, \OO_X)$ and $(Y, \OO_Y)$ be ringed spaces.
-We want to give a define what it means
+We want to define what it means
 to have a function $\pi \colon X \to Y$ between them.\footnote{Notational
 	connotations: for ringed spaces, $\pi$ will be used for maps,
 	since $f$ is often used for sections.}
@@ -44,7 +44,7 @@ for every open set $U$.
 		draw( (-9,0.5)--(-3,0.5), EndArrow);
 		label("$\pi$", (-6,0.5), dir(90));
 		label("$\boxed{f \in \mathcal O_Y(U)}$", (0,-5), red);
-		label("$\boxed{\pi^\sharp f \in \mathcal O_X(f^{\text{pre}}(U))}$",
+		label("$\boxed{\pi^\sharp f \in \mathcal O_X(\pi^{\text{pre}}(U))}$",
 			t*(0,-6), deepgreen);
 	\end{asy}
 \end{center}
@@ -52,7 +52,7 @@ for every open set $U$.
 Now, for general locally ringed spaces,
 the sections are just random rings,
 which may not be so well-behaved.
-So the solution is that we \emph{include} the data of $f^\sharp$
+So the solution is that we \emph{include} the data of $\pi^\sharp$
 as part of the definition of a morphism.
 \begin{remark}
 	As we will see in \Cref{ex:spec_C_morphism}, unlike the situation in algebraic varieties
@@ -315,7 +315,7 @@ which will force the ring homomorphisms to fix $\CC$, later.
 \end{example}
 But we could have used stalks, too.
 We wanted to specify a morphism
-\[ \RR[y]_{(y-3)} = \OO_{\Spec Y, (y-3)} \to \OO_{\Spec X, \kp} \]
+\[ \RR[y]_{(y-3)} = \OO_{Y, (y-3)} \to \OO_{X, \kp} \]
 for every prime ideal $\kp$,
 sending compatible germs to compatible germs\dots
 but wait, $(y-3)$ is spitting out all the germs.
@@ -323,7 +323,7 @@ So every \emph{individual} germ in $\OO_{\Spec Y, (y-3)}$
 needs to yield a (compatible) germ above every point of $\Spec X$,
 which is the data of an entire global section.
 So we're actually trying to specify
-\[ \RR[y]_{(y-3)} = \OO_{\Spec Y, (y-3)} \to \OO_{\Spec X}(\Spec X) = \RR[x]. \]
+\[ \RR[y]_{(y-3)} = \OO_{Y, (y-3)} \to \OO_{X}(X) = \RR[x]. \]
 This requires $y \mapsto 3$, as we saw,
 since $y-c$ is a unit of $\RR[x]$ for any $c \neq 3$.
 
@@ -353,7 +353,7 @@ You might already notice the following:
 	of $\CC[x]$, then it can never be mapped to the generic point $(0)$ of $\CC[y]$.
 
 	For otherwise, we would get a local ring homomorphism
-	\[ \CC(y) \cong \OO_{\Spec k[y], (0)}
+	\[ \CC(y) \cong \OO_{\Spec \CC[y], (0)}
 		\to \OO_{\Spec \CC[x], \km} \cong \CC[x]_\km \]
 	which in particular means we have a map on the residue fields
 	\[ \CC(y) \to \CC[x] / \km \cong \CC \]
@@ -404,7 +404,7 @@ of as the map $t \mapsto t^2$.
 \end{example}
 The above example works equally well if $t^2$ is replaced
 by some polynomial $f(t)$,
-so that $(x-a)$ maps to $(y-f(y))$.
+so that $(x-a)$ maps to $(y-f(a))$.
 The image of $y$ must be a polynomial $g(x)$
 with the property that $g(x)-c$ has the same roots as $f(x)-c$
 for any $c \in \CC$.
@@ -449,7 +449,7 @@ Put another way, $f$ and $g$ have the same values, so $f = g$.
 \section{The big theorem}
 We did a few examples of $\Spec A \to \Spec B$ by hand,
 specifying the full data of a map of locally ringed spaces.
-It turns out that in fact, we didn't to specify that much data,
+It turns out that in fact, we didn't have to specify that much data,
 and much of the process can be automated:
 \begin{proposition}
 	[Affine reconstruction]
@@ -514,7 +514,7 @@ and that we can get a suitable $\pi^\sharp$.
 We thus get the huge important theorem about affine schemes.
 \begin{theorem}
 	[$\Spec A \to \Spec B$ is just $B \to A$]
-	These two construction gives a bijection between
+	These two constructions give a bijection between
 	ring homomorphisms $B \to A$ and $\Spec A \to \Spec B$.
 \end{theorem}
 \begin{proof}
@@ -528,7 +528,7 @@ We thus get the huge important theorem about affine schemes.
 	Given $\psi \colon B \to A$, we define
 	$(\pi, \pi^\sharp) \colon \Spec A \to \Spec B$
 	by copying \Cref{prop:affine_reconstruction}
-	and checking that everything is well-definced.
+	and checking that everything is well-defined.
 	The details are:
 	\begin{itemize}
 	\ii For each prime ideal $\kp \in \Spec A$,

--- a/tex/alg-geom/sheaves.tex
+++ b/tex/alg-geom/sheaves.tex
@@ -40,11 +40,11 @@ with the interpretation that $\OO_V(U)$ was a ``ring of functions''.
 
 Recall from \Cref{sec:sheaf_regular_functions} that $\OO_V$, as a set, consist
 of simply the algebraic functions. However, if we view $\OO_V$ purely as a set,
-the structure of the functions is essentially thrown way.
+the structure of the functions is essentially thrown away.
 
 Let us see how the functions in $\OO_V$ are related to each other:
 \begin{itemize}
-	\ii Each function in $\OO_V$ is defined on a open set $U \subseteq V$.
+	\ii Each function in $\OO_V$ is defined on an open set $U \subseteq V$.
 	\ii If two functions are defined on the same open set, you can add and
 	multiply them together. In other words, $\OO_V(U)$ is a ring.
 	\ii Given a function $f \in \OO_V(U)$, we can restrict it to a smaller open
@@ -410,8 +410,8 @@ so we do it carefully now.
 \begin{remark}
 	[Aside for category lovers]
 	You may notice that $\SF_p$ seems to be
-	``all the $\SF_p(U)$ coming together'', where $p \in U$.
-	And in fact, $\SF_p(U)$ is the categorical \emph{colimit}
+	``all the $\SF(U)$ coming together'', where $p \in U$.
+	And in fact, $\SF_p$ is the categorical \emph{colimit}
 	of the diagram formed by all the $\SF(U)$ such that $p \in U$.
 	This is often written
 	\[ \SF_p = \varinjlim_{U \ni p} \SF(U) \]

--- a/tex/alg-geom/spec-examples.tex
+++ b/tex/alg-geom/spec-examples.tex
@@ -11,7 +11,7 @@ be better than your algebraic one.
 For example, while studying $k[x,y] / (xy)$ you will say
 ``geometrically, I expect so-and-so to look like other thing'',
 but when you write down the algebraic statements
-you find two expressions that are don't look equal to you.
+you find two expressions that don't look equal to you.
 However, if you then do some calculation you will
 find that they were isomorphic after all.
 So in that sense, in this chapter you will learn to begin drawing
@@ -41,7 +41,7 @@ We will also use the following color connotations:
 This one is easy: for any field $k$,
 $X = \Spec k$ has a single point,
 corresponding to the only proper ideal $(0)$.
-There is only way to put a topology on it.
+There is only one way to put a topology on it.
 
 As for the sheaf,
 \[ \OO_X(X) = \OO_{X,(0)} = k. \]
@@ -105,7 +105,7 @@ consider the generic point $\eta = (0)$.
 
 What is the stalk $\OO_{X, \eta}$?
 Well, it should be $\CC[x]_{(0)} = \CC(x)$,
-which is the again the set of \emph{rational} functions.
+which is again the set of \emph{rational} functions.
 And that's what you expect.
 For example, $\frac{x^2+8}{(x-1)(x-5)}$
 certainly describes a rational function on ``most'' complex numbers.
@@ -230,7 +230,7 @@ so a ``rational function'' is literally a rational number!
 Thus, $\frac{20}{19}$ is a function
 with a double root at $(2)$, a root at $(5)$,
 and a simple pole at $(19)$.
-If we evaluate it at $\kp = (7)$, we get $3 \pmod 7$.
+If we evaluate it at $\kp = (7)$, we get $4 \pmod 7$.
 In general, the residue fields are what you'd guess:
 \[ \kappa\left( (p) \right) = \ZZ/(p) \cong \FF_p \]
 for each prime $p$, and
@@ -286,7 +286,7 @@ as the space is discrete, all points are closed.
 We can now elaborate on the ``double point'' scheme
 \[ X_2 = \Spec k[x] / (x^2) \]
 since it is such an important motivating example.
-How it does differ from the ``one-point'' scheme
+How does it differ from the ``one-point'' scheme
 $X_1 = \Spec k[x] / (x) = \Spec k$?
 Both $X_2$ and $X_1$ have exactly one point,
 and so obviously the topologies are the same too.
@@ -430,7 +430,7 @@ We also go ahead and compute the stalks above each point.
 Let's consider the global section $f = x^2 + y^2$
 and also take the value at each of the above points.
 \begin{itemize}
-	\ii $f \pmod{x-1,y-2} = 5$, so $f$ has value $5$ at $(x-1, y+2)$.
+	\ii $f \pmod{x-1,y+2} = 5$, so $f$ has value $5$ at $(x-1, y+2)$.
 	\ii The new bit is that we can think of evaluating
 	$f$ along the parabola too --- it is given a particular value
 	in the quotient $k[x,y] / (y-x^2)$.
@@ -538,7 +538,7 @@ Also unsurprising.
 Finally, we expect the parabola is actually isomorphic to $\Spec k[x]$,
 since there is an isomorphism $k[x,y] / (y-x^2) \cong k[x]$
 by sending $y \mapsto x^2$.
-Pictorially, this looks like ``un-bending'' the hyperbola.
+Pictorially, this looks like ``un-bending'' the parabola.
 In general, we would hope that when two rings $A$ and $B$ are isomorphic,
 then $\Spec A$ and $\Spec B$ should be ``the same''
 (otherwise we would be horrified),
@@ -585,7 +585,7 @@ To make sure things are making sense:
 	lying in $\VV(x)$.
 \end{ques}
 
-The ideal $(0)$ is longer prime,
+The ideal $(0)$ is no longer prime,
 so it is not a point of this space.
 Rather, there are two non-closed points this time:
 the ideals $(x)$ and $(y)$,
@@ -716,7 +716,7 @@ You can try to work out the statement now if you want, but we won't do so.
 %%fakechapter 1D with holes
 \section{$\Spec k[x,x\inv]$, the punctured line (or hyperbola)}
 This is supposed to look like $D(x)$ of $\Spec k[x]$,
-or the line with the origin deleted it.
+or the line with the origin deleted.
 Alternatively, we could also write
 \[ k[x,x\inv] \cong k[x,y] / (xy-1) \]
 so that the scheme could also be drawn as a hyperbola.
@@ -746,7 +746,7 @@ So again, we see that the deletion of the origin
 doesn't affect the stalk at the farther away point $(x-3)$.
 
 As mentioned, since $k[x,x\inv]$ is isomorphic to $k[x,y] / (xy-1)$,
-another way to draw the visualize the same curve
+another way to visualize the same curve
 would be to draw the hyperbola
 (which you can imagine as flattening to give the punctured line.)
 There is one generic point $(0)$ since $k[x,y]/(xy-1)$
@@ -808,7 +808,7 @@ if you pluck out that stalk from the affine line.
 
 Since $k[x]_{(x)}$ is a local ring
 (it is the localization of a prime ideal),
-this point has only one closed point: the maximal ideal $(x)$.
+this space has only one closed point: the maximal ideal $(x)$.
 However, surprisingly, it has one more point:
 a ``generic'' point $(0)$.
 So $\Spec k[x]_{(x)}$ is a \emph{two-point space},

--- a/tex/alg-geom/spec-sheaf.tex
+++ b/tex/alg-geom/spec-sheaf.tex
@@ -93,7 +93,7 @@ We will now really hammer in the importance of
 the distinguished open sets.
 The definition is analogous to before:
 \begin{definition}
-	Let $f \in \Spec A$.
+	Let $f \in A$.
 	Then $D(f)$ is the set of $\kp$ such that $f(\kp) \neq 0$,
 	a \vocab{distinguished open set}.
 \end{definition}
@@ -257,7 +257,7 @@ Don't worry, this one is easier than last section.
 	\begin{itemize}
 		\ii Injective: suppose $(U_1, f_1 / g_1)$ and $(U_2, f_2 / g_2)$
 		are two germs with $f_1/g_1 = f_2/g_2 \in A_\kp$.
-		This means $h(g_1 f_2 - f_2 g_1) = 0$ in $A$, for some nonzero $h$.
+		This means $h(f_1 g_2 - f_2 g_1) = 0$ in $A$, for some $h \notin \kp$.
 		Then both germs identify with
 		the germ $(U_1 \cap U_2 \cap D(h), f_1 / g_1)$.
 		\ii Surjective: let $U = D(g)$. \qedhere
@@ -270,7 +270,7 @@ Don't worry, this one is easier than last section.
 	that I will only write it in the new notation,
 	and make no further comment:
 	if $X = \Spec \CC[x]$ then
-	\[ \OO_{\Spec X, (x)} = \CC[x]_{(x)}
+	\[ \OO_{X, (x)} = \CC[x]_{(x)}
 		= \left\{  \frac fg \mid g(0) \neq 0 \right\}. \]
 \end{example}
 \begin{example}
@@ -294,7 +294,7 @@ The stalk was
 So let's take some section like $f = \frac{1}{xy + 4}$,
 which is a section of $U = D(xy+4)$ (or some smaller open set,
 but we'll just use this one for simplicity).
-We also have $U \ni m$, and so $f$ gives a germ at $\km$.
+We also have $U \ni \km$, and so $f$ gives a germ at $\km$.
 
 On the other hand, $f$ also has a value at $\km$:
 it is $f \pmod{\km} = \frac 14$.
@@ -341,7 +341,7 @@ give our examples in the proper language.
 \begin{definition}
 	A ring $R$ with exactly one maximal ideal $\km$
 	will be called a \vocab{local ring}.
-	The \vocab{residue field} is the quotient $A / \km$.
+	The \vocab{residue field} is the quotient $R / \km$.
 \end{definition}
 \begin{ques}
 	Are fields local rings?
@@ -576,7 +576,7 @@ it's likely to be worth reading even before attempting these problems.
 
 \begin{problem}
 	[Punctured gyrotop, communicated by Aaron Pixton]
-	The gyrotop is the scheme $X = \Spec \CC[x,y,z] / (xy,z)$.
+	The gyrotop is the scheme $X = \Spec \CC[x,y,z] / (xz,yz)$.
 	We let $U$ denote the open subset obtained
 	by deleting the closed point $\km = (x,y,z)$.
 	Compute $\OO_X(U)$.
@@ -607,7 +607,7 @@ it's likely to be worth reading even before attempting these problems.
 
 \begin{problem}
 	Show that a ring $R$ is a local ring
-	if and only of the following property is true:
+	if and only if the following property is true:
 	for any $x \in R$,
 	either $x$ or $1-x$ is a unit.
 \end{problem}

--- a/tex/alg-geom/spec-zariski.tex
+++ b/tex/alg-geom/spec-zariski.tex
@@ -126,7 +126,7 @@ there is one for each non-maximal prime ideal
 (visualized as ``irreducible subvariety'').
 I like to visualize them in my head like a fly:
 you can hear it, so you know it is floating \emph{somewhere} in the room,
-but as it always moving, you never know exactly where.
+but as it is always moving, you never know exactly where.
 So the generic point of $\Spec \CC[x,y]$ corresponding to the prime
 ideal $(0)$ is floating everywhere in the plane,
 the one for the ideal $(y-x^2)$ floats along the parabola, etc.
@@ -175,14 +175,14 @@ the analogy by thinking of the points $f$ as functions on $\Spec A$. That is:
 	[Vanishing locii in $\Aff^n$]
 	Suppose $A = \CC[x_1, \dots, x_n]$,
 	and $\km = (x_1-a_1, x_2-a_2, \dots, x_n-a_n)$ is a maximal ideal of $A$.
-	Then for a polynomial $f \in \CC$,
+	Then for a polynomial $f \in A$,
 	\[ f \pmod \km = f(a_1, \dots, a_n) \]
 	with the identification that $A/\km \cong \CC$.
 \end{example}
 \begin{example}
 	[Functions on $\Spec \ZZ$]
-	Consider $A = \Spec \ZZ$.
-	Then $2019$ is a function on $A$.
+	Consider $A = \ZZ$.
+	Then $2019$ is a function on $\Spec A$.
 	Its value at the point $(5)$ is $4 \pmod 5$;
 	its value at the point $(7)$ is $3 \pmod 7$.
 \end{example}
@@ -222,7 +222,7 @@ Recall also in \Cref{def:closure} we denote by $\ol S$
 the closure of a set $S$ (i.e.\ the smallest closed set containing $S$);
 so you can think of a closed point $p$ also
 as one whose closure is just $\{p\}$.
-Therefore the Zariski topology lets us refer back to the old ``geometric''
+Therefore the Zariski topology lets us refer back to the old ``geometric'' points
 as just the closed points.
 
 \begin{example}
@@ -382,7 +382,7 @@ For affine schemes:
 	Consider chains of prime ideals
 	$\kp_0 \subsetneq \kp_1 \subsetneq \dots \subsetneq \kp_n \subseteq A$,
 	where $n$ is called the \emph{length}.
-	The supremum of all possible $n$ is the called \vocab{Krull dimension} of $A$.
+	The supremum of all possible $n$ is then called the \vocab{Krull dimension} of $A$.
 
 	The Krull dimension is always nonnegative unless $A$ is the zero ring,
 	in which case either $-1$ or $-\infty$ are used conventionally.
@@ -398,7 +398,7 @@ This definition should match your intuition.
 		having length $n$.
 		This matches our expectation that $\Spec \CC[x_1, \dots, x_n]$ corresponds to $\Aff^n$.
 		\ii $\CC[x,y] / (y-x^2)$ has Krull dimension $1$, with the chain
-		\[ (x,y) \subsetneq (y-x^2) \]
+		\[ (y-x^2) \subsetneq (x,y) \]
 		having length $1$.
 		Geometrically, we think of $(x,y)$ as the origin and $(y-x^2)$ as the parabola itself.
 		\ii $\ZZ$ has Krull dimension $1$.
@@ -535,7 +535,7 @@ We can now state:
 \begin{theorem}
 	[Radical ideals correspond to closed sets]
 	Let $I$ and $J$ be ideals of $A$,
-	and considering the space $\Spec A$.
+	and consider the space $\Spec A$.
 	Then
 	\[ \VV(I) = \VV(J) \iff \sqrt I = \sqrt J. \]
 	In particular, radical ideals exactly


### PR DESCRIPTION
Proofreading pass over the **Algebraic Geometry II: Affine Schemes** part (part of the #315 campaign), covering the six chapters: `sheaves`, `localization`, `spec-zariski`, `spec-sheaf`, `spec-examples`, `mor-scheme`.

Most fixes are minor typos and grammar. A few small mathematical/notational corrections are worth calling out:

### Math / calculation fixes
- **`spec-sheaf.tex`** (gyrotop problem): the scheme was written `Spec ℂ[x,y,z]/(xy,z)`, but that collapses `z=0` everywhere and is inconsistent with the given solution (which uses `A_z ≅ k[z,z⁻¹]`, a punctured line, and `(xz,yz)`). Corrected to `(xz,yz)` — the plane-plus-axis "top" shape the problem intends.
- **`spec-sheaf.tex`** (stalks-are-localizations proof): the injectivity step had `h(g₁f₂ − f₂g₁) = 0`, but `g₁f₂ − f₂g₁ ≡ 0` identically. Corrected to `h(f₁g₂ − f₂g₁) = 0` (the genuine cross-multiplication), and tightened "some nonzero `h`" to "some `h ∉ 𝔭`" so the subsequent `D(h)` step is valid.
- **`spec-zariski.tex`** (Krull dimension example): the length-1 chain for `ℂ[x,y]/(y−x²)` was written `(x,y) ⊊ (y−x²)`, which is the reversed (and false) inclusion. Corrected to `(y−x²) ⊊ (x,y)`.
- **`spec-examples.tex`**: evaluating `20/19` at `(7)` gives `4 (mod 7)`, not `3` (since `19≡5`, `20≡6`, `6·5⁻¹ ≡ 6·3 ≡ 4`).
- **`localization.tex`**: `A_(x) = {f/g : g(0)≠0}` was described as "the Laurent series"; it is actually the rational functions with no pole at the origin (Laurent series/polynomials are the *other* localization). Reworded.
- **`mor-scheme.tex`**: general `t↦t²` remark said `(x−a)` maps to `(y−f(y))`; should be `(y−f(a))`.

### Notation fixes
- `spec-zariski.tex`: `f ∈ ℂ` → `f ∈ A` for a polynomial; `A = Spec ℤ` → `A = ℤ` (with "function on `Spec A`").
- `spec-sheaf.tex`: `f ∈ Spec A` → `f ∈ A`; `𝒪_{Spec X,(x)}` → `𝒪_{X,(x)}` (double `Spec`); residue field `A/𝔪` → `R/𝔪`; `U ∋ m` → `U ∋ 𝔪`.
- `mor-scheme.tex`: several `𝒪_{Spec X}`/`𝒪_{Spec Y}` (double `Spec` on spaces `X,Y`) → `𝒪_X`/`𝒪_Y`; `k[y]` → `ℂ[y]`; `f^♯` → `π^♯` and `f^{pre}` → `π^{pre}`.
- `sheaves.tex`: category-lovers aside wrote `𝒮ℱ_p(U)`; corrected to `𝒮ℱ(U)` / `𝒮ℱ_p`.

### Typos / grammar
- `sheaves.tex`: "thrown way" → "thrown away"; "a open set" → "an open set".
- `localization.tex`: "also explain" → "explains"; "those elements of those elements" → "those elements".
- `spec-zariski.tex`: "as it always moving" → "as it is always moving"; "old ``geometric'' " → "old ``geometric'' points"; "is the called" → "is then called the"; "considering the space" → "consider the space".
- `spec-examples.tex`: "are don't look" → "don't look"; "only way" → "only one way"; "is the again" → "is again"; "How it does differ" → "How does it differ"; `pmod{x-1,y-2}` → `pmod{x-1,y+2}`; "un-bending the hyperbola" → "un-bending the parabola" (parabola section); "(0) is longer prime" → "no longer prime"; "deleted it" → "deleted"; "draw the visualize" → "visualize"; "this point has only one closed point" → "this space".
- `spec-sheaf.tex`: "if and only of" → "if and only if".
- `mor-scheme.tex`: "give a define" → "define"; "didn't to specify" → "didn't have to specify"; "two construction gives" → "two constructions give"; "well-definced" → "well-defined".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiWD2kTJcNfuLWc1AKKa41)_