### PR TITLE
fix: proofread Set Theory I part

### DIFF
--- a/tex/set-theory/cardinal.tex
+++ b/tex/set-theory/cardinal.tex
@@ -386,7 +386,7 @@ In fact, if the cofinality of an ordinal is itself, then that ordinal must be a 
 Such a cardinal is called \vocab{regular}.
 \begin{example}[$\aleph_0$ is regular]
 	$\cof(\aleph_0) = \aleph_0$, because no finite subset of
-	$\aleph_ 0 = \omega$ can reach arbitrarily high.
+	$\aleph_0 = \omega$ can reach arbitrarily high.
 \end{example}
 \begin{example}[$\aleph_1$ is regular]
 	$\cof(\aleph_1) = \aleph_1$.
@@ -433,7 +433,7 @@ It seems that most of them are singular: if $\aleph_\lambda \neq \aleph_0$ is a 
 is, $\lambda$ is a limit ordinal),
 then the sequence $\{\aleph_\alpha\}_{\alpha \in \lambda}$ (of length $\lambda$) is certainly cofinal.
 
-\begin{example}[Beth fixed point]
+\begin{example}[Aleph fixed point]
 	Consider the monstrous cardinal
 	\[ \kappa = \aleph_{\aleph_{\aleph_{\ddots}}}. \]
 	This might look frighteningly huge, as $\kappa = \aleph_\kappa$,

--- a/tex/set-theory/zfc.tex
+++ b/tex/set-theory/zfc.tex
@@ -66,7 +66,7 @@ This is bad, since:
 \begin{proof}
 	Assume for contradiction $\iota$ exists.
 	\begin{exercise}
-		Show that if, $\iota$ exists,
+		Show that if $\iota$ exists,
 		then there exists a surjective map $j \colon X \surjto \PP(X)$.
 		(This is easier than it appears, just ``invert $\iota$'').
 	\end{exercise}

--- a/tex/set-theory/zorn-lemma.tex
+++ b/tex/set-theory/zorn-lemma.tex
@@ -355,7 +355,7 @@ But really, it's nothing special.
 		\ii The function $f$ is not a bijection from $(0,\infty)$ to $\RR$.
 		\ii It's possible for $f$ to be injective but not linear.
 		\ii It's possible for $f$ to be surjective but not linear.
-		\ii It's possible for $f$ is nonconstant and $f(x) \in \QQ$ for all $x \in \RR$.
+		\ii It's possible that $f$ is nonconstant and $f(x) \in \QQ$ for all $x \in \RR$.
 		\ii It's possible that $f$ is nonconstant and $f(x) \notin \QQ$
 		for all nonzero $x \in \RR$.
 	\end{enumerate}


### PR DESCRIPTION
This PR proofreads the **Set Theory I: ZFC, Ordinals, and Cardinals** part (issue #315), covering:

- `tex/set-theory/zorn-lemma.tex`
- `tex/set-theory/zfc.tex`
- `tex/set-theory/ordinal.tex`
- `tex/set-theory/cardinal.tex`

All the substantive mathematics checks out — the bijection tables ($\omega+1 \approx \omega$, $\omega \approx \omega^2$), ordinal/cardinal arithmetic constructions, the von Neumann hierarchy computations ($V_3 = \{0,1,2,\{1\}\}$), and the $\kappa \cdot \kappa = \kappa$ proof with its $<_{\max}$ enumeration table all verify correctly.

Only a few minor issues were found and fixed:

- **`zfc.tex`**: stray comma in the Cantor diagonal exercise — "Show that if, $\iota$ exists," → "Show that if $\iota$ exists,".
- **`zorn-lemma.tex`**: grammatical slip in the Cauchy functional-equation problem — "It's possible for $f$ is nonconstant …" → "It's possible that $f$ is nonconstant …", matching the phrasing of the adjacent item.
- **`cardinal.tex`**: stray space inside a subscript, $\aleph_ 0$ → $\aleph_0$.
- **`cardinal.tex`**: the example titled "Beth fixed point" actually concerns the *aleph* function ($\kappa = \aleph_{\aleph_{\aleph_\ddots}}$, so $\kappa = \aleph_\kappa$), not the beth function; retitled to "Aleph fixed point".

No large mathematical errors were found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYnQwxZGUNjX354EBzZoRN

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYnQwxZGUNjX354EBzZoRN)_