### PR TITLE
fix: proofread Set Theory II part

### DIFF
--- a/tex/set-theory/CH.tex
+++ b/tex/set-theory/CH.tex
@@ -291,7 +291,7 @@ This is purely combinatorial, and so we work briefly.
 	The base case $n=1$ is trivial, since we can just take $R = \varnothing$.
 	For the inductive step we consider two cases.
 
-	First, assume there exists an $a \in C$ contained in uncountably many $F \in C$.
+	First, assume there exists an element $a$ contained in uncountably many $F \in C$.
 	Throw away all the other guys.
 	Then we can just delete $a$, and apply the inductive hypothesis.
 
@@ -312,8 +312,8 @@ This is purely combinatorial, and so we work briefly.
 	\[ C = \left\{ \dom(p_\alpha) \mid \alpha < \omega_1 \right\}. \]
 	Let $\ol C \subseteq C$ be such that $\ol C$ is uncountable, and $\ol C$ is a $\Delta$-system with root $R$.
 	Then let
-	\[ B = \left\{ p_\alpha \mid \dom(p_\alpha) \in R \right\}. \]
-	Each $p_\alpha \in B$ is a function $p_\alpha \colon R \to \{0,1\}$,
+	\[ B = \left\{ p_\alpha \mid \dom(p_\alpha) \in \ol C \right\}. \]
+	Each $p_\alpha \in B$ restricts to a function $p_\alpha \restriction R \colon R \to \{0,1\}$,
 	so there are two that are the same.
 \end{proof}
 

--- a/tex/set-theory/forcing.tex
+++ b/tex/set-theory/forcing.tex
@@ -259,7 +259,7 @@ We had better make sure that generic filters exist.
 \begin{example}
 	If $\Po$ is the infinite binary tree and $M$ contains every subset of $\Po$, then generic filter
 	does not exist --- for every filter $G \subseteq \Po$, $\Po \setminus G$ is a dense set $D \in
-	M$, and $G \cap M = \varnothing$.
+	M$, and $G \cap D = \varnothing$.
 \end{example}
 In fact this is kind of tricky, but for countable models it works:
 \begin{lemma}[Rasiowa-Sikorski lemma]
@@ -545,10 +545,10 @@ In other words, we want to choose the definition of $p \Vdash \tau_1 \in \tau_2$
 		\mid \exists \left<\tau, r\right> \in \tau_2
 		\left( q \le r \land q \Vdash(\tau=\tau_1) \right) \right\}
 \]
-is dense below in $p$.
+is dense below $p$.
 In other words, if the set is dense, then the generic must hit $q$, so it must hit $r$
 (recall that a filter is upwards-closed),
-meaning that $\left<\tau_r\right> \in \tau_2$ will get interpreted such that $\tau^G \in \tau_2^G$, and moreover the $q \in G$ will force $\tau_1 = \tau$.
+meaning that $\left<\tau, r\right> \in \tau_2$ will get interpreted such that $\tau^G \in \tau_2^G$, and moreover the $q \in G$ will force $\tau_1 = \tau$.
 
 Now let's write down the definition\dots
 In what follows, the $\Vdash$ omits the $M$ and $\Po$.
@@ -557,7 +557,7 @@ In what follows, the $\Vdash$ omits the $M$ and $\Po$.
 	Let $\Po \in M$ be a partial order.
 	For $p \in \Po$ and $\varphi(\sigma_1, \dots, \sigma_n)$
 	a formula in the language of set theory,
-	we write $\tau \Vdash \varphi(\sigma_1, \dots, \sigma_n)$
+	we write $p \Vdash \varphi(\sigma_1, \dots, \sigma_n)$
 	to mean the following, defined by induction on formula complexity plus rank.
 	\begin{enumerate}[(1)]
 		\ii $p \Vdash \tau_1 = \tau_2$ means
@@ -568,7 +568,7 @@ In what follows, the $\Vdash$ omits the $M$ and $\Po$.
 				\left\{ r \mid
 				r \le q_1 \lthen \exists \left<\sigma_2, q_2\right> \in \tau_2 \left( r \le q_2 \land r \Vdash (\sigma_1 = \sigma_2) \right)\right\}.
 			\]
-			is dense in $p$.
+			is dense below $p$.
 			(This encodes ``$\tau_1 \subseteq \tau_2$''.)
 			\ii For all $\left<\sigma_2, q_2\right> \in \tau_2$,
 			the set $D_{\sigma_2, q_2}$ defined similarly is dense below $p$.

--- a/tex/set-theory/models.tex
+++ b/tex/set-theory/models.tex
@@ -686,8 +686,8 @@ the uncountable $\aleph_1^M$ is really just an ordinary countable ordinal.
 	\begin{hint}
 		This is very similar to the proof of L\"owenheim-Skolem.
 		For a sentence $\phi$, let $f_\phi$
-		send $\alpha$ to the least $\beta < \kappa$ such that for all $\vec b \in V_\alpha$, if there exists $a \in M$ such that $V_\kappa \vDash \phi[a, \vec b]$ then $\exists a \in V_\beta$ such that $V_\kappa \vDash \phi[a, \vec b]$.
-		(To prove this $\beta$ exists, use the fact that $\kappa$ is cofinal.)
+		send $\alpha$ to the least $\beta < \kappa$ such that for all $\vec b \in V_\alpha$, if there exists $a \in V_\kappa$ such that $V_\kappa \vDash \phi[a, \vec b]$ then $\exists a \in V_\beta$ such that $V_\kappa \vDash \phi[a, \vec b]$.
+		(To prove this $\beta$ exists, use the fact that $\kappa$ is regular.)
 		Then, take the supremum over the countably many sentences for each $\alpha$.
 	\end{hint}
 	\begin{sol}


### PR DESCRIPTION
Proofreads the **Set Theory II: Model Theory and Forcing** part (issue #315), covering `tex/set-theory/models.tex`, `tex/set-theory/forcing.tex`, and `tex/set-theory/CH.tex`.

All findings are minor typos / notational slips; no mathematical arguments were rewritten.

### `models.tex` — Reflection problem hint
- The hint quantified `if there exists $a \in M$`, but `M` is never defined in this problem (it's about $V_\kappa$). Changed to `a \in V_\kappa`, matching the solution.
- "use the fact that $\kappa$ is cofinal" → "$\kappa$ is **regular**". Cofinality isn't a standalone property of a cardinal here, and the solution itself invokes regularity.

### `forcing.tex`
- Non-existence-of-generic example: `$G \cap M = \varnothing$` → `$G \cap D = \varnothing$`. The point is that $G$ misses the dense set $D = \Po\setminus G$; $G \cap M$ is just $G$.
- Motivation for the forcing relation: `$\left<\tau_r\right>$` → `$\left<\tau, r\right>$` (missing comma in the pair).
- Definition of the forcing relation: "we write $\tau \Vdash \varphi$" → "$p \Vdash \varphi$" ($p \in \Po$ was just introduced; the body uses $p \Vdash$ throughout).
- Two phrasing fixes for consistency with the standard term: "dense below in $p$" → "dense below $p$", and "dense in $p$" → "dense below $p$".

### `CH.tex` — countable chain condition
- $\Delta$-system lemma proof: "there exists an $a \in C$ contained in uncountably many $F \in C$" → "an **element** $a$ contained in …" ($a$ is a point that lies in uncountably many members, not itself a member of $C$).
- ccc proof of $\opname{Add}(\omega,\kappa)$: `$B = \{p_\alpha \mid \dom(p_\alpha) \in R\}$` → `\in \ol C` (we keep the conditions whose domains lie in the $\Delta$-system $\ol C$; $R$ is the root, so $\dom(p_\alpha)\in R$ is a type error). Also clarified that $p_\alpha$ is **restricted** to $R$ before comparing (each $p_\alpha\restriction R \colon R \to \{0,1\}$), since finitely many such restrictions forces a collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PXK5YtzH5S2FyB9XcXmE1

---
_Generated by [Claude Code](https://claude.ai/code/session_014PXK5YtzH5S2FyB9XcXmE1)_