### PR TITLE
fix: proofread Appendix part

### DIFF
--- a/tex/backmatter/notation.tex
+++ b/tex/backmatter/notation.tex
@@ -86,8 +86,8 @@ Linear algebra:
 	\ii $V \otimes W$: tensor product
 	\ii $V^{\otimes n}$: tensor product of $V$, $n$ times
 	\ii $V^\vee$: dual space
-	\ii $T^\vee$: dual map (for $T$ a vector space)
-	\ii $T^\dagger$: conjugate transpose (for $T$ a vector space)
+	\ii $T^\vee$: dual map (for $T$ a linear map)
+	\ii $T^\dagger$: conjugate transpose (for $T$ a linear map)
 	\ii $\left< -,-\right>$: a bilinear form
 	\ii $\Mat(V)$: endomorphisms of $V$, i.e.\ $\Hom_k(V,V)$
 	\ii $\ee_1$, \dots, $\ee_n$: the ``standard basis'' of $k^{\oplus n}$
@@ -96,7 +96,7 @@ Linear algebra:
 \begin{itemize}
 	\ii $\ket{\psi}$: a vector in some vector space $H$
 	\ii $\bra{\psi}$: a vector in some vector space $H^\vee$, dual to $\ket{\psi}$.
-	\ii $\braket{\phi|\psi}$: evaluation of an element $\bra{\phi} \in H^\vee$ at $\ket{\phi} \in H$.
+	\ii $\braket{\phi|\psi}$: evaluation of an element $\bra{\phi} \in H^\vee$ at $\ket{\psi} \in H$.
 	\ii $\zup$, $\zdown$: spin $z$-up, spin $z$-down
 	\ii $\xup$, $\xdown$: spin $x$-up, spin $x$-down
 	\ii $\yup$, $\ydown$: spin $y$-up, spin $y$-down
@@ -138,7 +138,7 @@ Complex analysis:
 \end{itemize}
 \section{Measure theory and probability}
 \begin{itemize}
-	\ii $\SA\cme$: the $\sigma$-algebra of Caratheory-measurable sets
+	\ii $\SA\cme$: the $\sigma$-algebra of Carath\'{e}odory-measurable sets
 	\ii $\SB(X)$: the Borel space for $X$
 	\ii $\mu\cme$: the induced measure on $\SA\cme$.
 	\ii $\lambda$: Lebesgue measure
@@ -209,7 +209,7 @@ Operations with categories:
 \section{Differential geometry}
 \begin{itemize}
 	\ii $Df$: total derivative of $f$
-	\ii $(Df)_p$: total derivate of $f$ at point $p$
+	\ii $(Df)_p$: total derivative of $f$ at point $p$
 	\ii $\fpartial{f}{e_i}$: $i^{\text{th}}$ partial derivative
 	\ii $\alpha_p$: evaluating a $k$-form $\alpha$ at $p$
 	\ii $\int_c \alpha$: integration of the differential form $\alpha$ over a cell $c$

--- a/tex/backmatter/sets-functions.tex
+++ b/tex/backmatter/sets-functions.tex
@@ -233,7 +233,7 @@ The dual notion is:
 \section{Equivalence relations}
 Let $X$ be a fixed set now.
 A binary relation $\sim$ on $X$ assigns a truth value ``true''
-or ``false'' to $x \sim y$ for each $x$ or $y$.
+or ``false'' to $x \sim y$ for each $x$ and $y$.
 Now an \vocab{equivalence relation} $\sim$ on $X$ is a binary relation
 which satisfies the following axioms:
 \begin{itemize}


### PR DESCRIPTION
Part of the proofreading campaign (#315): the **Appendix** part, covering the backmatter chapters included under `\part{Appendix}` in `Napkin.tex` (`tex/backmatter/references.tex`, `notation.tex`, `sets-functions.tex`; `hintsol.tex` is auto-generated and has no prose to check).

All findings are minor typos and wording errors:

**`tex/backmatter/notation.tex`**
- `$T^\vee$` (dual map) and `$T^\dagger$` (conjugate transpose) were both annotated "for $T$ a vector space" — but $T$ is a linear map in each case (cf. `tex/linalg/transpose.tex`, where `$T^\dagger \colon W \to V$` is a map). Changed to "for $T$ a linear map".
- `$\braket{\phi|\psi}$` was described as evaluation of `$\bra{\phi}$` at `$\ket{\phi} \in H$`; the second element should be `$\ket{\psi}$`.
- "Caratheory-measurable" → "Carath\'{e}odory-measurable" (matches the spelling used in `tex/measure/caratheodory.tex`).
- "total derivate" → "total derivative".

**`tex/backmatter/sets-functions.tex`**
- A binary relation assigns a truth value to `$x \sim y$` "for each $x$ **and** $y$", not "for each $x$ or $y$".

No large mathematical errors were found; `references.tex` read cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01746Avzf72XowRprtRtPviq)_