### PR TITLE
fix: some minor mistakes

### DIFF
--- a/tex/calculus/differentiate.tex
+++ b/tex/calculus/differentiate.tex
@@ -559,8 +559,7 @@ easily decouple; the following form may be more useful in that case.
 \begin{theorem}
 	[Ratio mean value theorem]
 	Let $f, g \colon [a,b] \to \RR$ be two continuous functions
-	which are differentiable on $(a,b)$,
-	and such that $g(a) \neq g(b)$.
+	which are differentiable on $(a,b)$.
 	Then there exists $c \in (a,b)$ such that
 	\[ f'(c)(g(b)-g(a)) = g'(c)(f(b)-f(a)) \]
 \end{theorem}

--- a/tex/complex-ana/holomorphic.tex
+++ b/tex/complex-ana/holomorphic.tex
@@ -746,9 +746,9 @@ be $0$.
 
 Next step, we should show the power series coincide with $f$, that is
 \[ f(z) =
-\oint_\gamma \frac{f(t)}{t} \; dt +
-\oint_\gamma \frac{f(t)}{t^2} \; dt \cdot z +
-\oint_\gamma \frac{f(t)}{t^3} \; dt \cdot z^2 + \cdots \]
+\frac{1}{2\pi i} \oint_\gamma \frac{f(t)}{t} \; dt +
+\frac{1}{2\pi i} \oint_\gamma \frac{f(t)}{t^2} \; dt \cdot z +
+\frac{1}{2\pi i} \oint_\gamma \frac{f(t)}{t^3} \; dt \cdot z^2 + \cdots \]
 Here we assume $\gamma$ is the unit circle, the power series is centered at $0$, and $t$ is inside
 the unit disk.
 \begin{exercise}

--- a/tex/measure/caratheodory.tex
+++ b/tex/measure/caratheodory.tex
@@ -632,8 +632,7 @@ when $\mu_0$ is $\sigma$-finite.
 			\end{cases}
 		\]
 		This lets you solve (b) readily;
-		I think the answer is just unbounded sets,
-		$\varnothing$, and one-point sets.
+		the answer is just $\varnothing$ and $\Omega$.
 	\end{hint}
 \end{problem}
 

--- a/tex/measure/lebesgue-int.tex
+++ b/tex/measure/lebesgue-int.tex
@@ -150,11 +150,11 @@ requiring both are finite, and then integrating.
 To finish this section, we state for completeness
 some results that you probably could have guessed were true.
 Fix $\Omega = (\Omega, \SA, \mu)$, and
-let $f$ and $g$ be measurable real-valued functions
-such that $f(x) = g(x)$ almost everywhere.
+let $f$ and $g$ be measurable real-valued functions.
 \begin{itemize}
 	\ii (Almost-everywhere preservation)
-	The function $f$ is absolutely integrable if and only if $g$ is,
+	If $f(x) = g(x)$ almost everywhere then
+	$f$ is absolutely integrable if and only if $g$ is,
 	and if so, their Lebesgue integrals match.
 	\ii (Additivity)
 	If $f$ and $g$ are absolutely integrable then

--- a/tex/measure/swapsum.tex
+++ b/tex/measure/swapsum.tex
@@ -83,7 +83,7 @@ Unfortunately, pointwise convergence is actually a fairly weak notion of converg
 		\to \infty$, for every $k$ then $\int f_k(x) \; dx=1$, but $\int f(x) \; dx=0$.
 
 		Note that, in this case, the convergence is actually uniform!
-		\ii We don't even need $k$ in the denominator --- the sequence $f_k(x) = \mathbf{1}_{(0, k)}$ also
+		\ii We don't even need $k$ in the denominator --- the sequence $f_k(x) = \mathbf{1}_{(k, \infty)}$ also
 		converges pointwise to $f(x)=0$, but this time, for every $k$ then $\int f_k(x) \; dx=\infty$!
 		\ii The sequence $f_k(x) = k \cdot \mathbf{1}_{(0, 1/k)}$ converges pointwise to $f(x)=0$ as $k
 		\to \infty$. But similar to above, $\int f_k(x) \; dx=1$ for every $k$, but

--- a/tex/rep-theory/applications.tex
+++ b/tex/rep-theory/applications.tex
@@ -150,7 +150,7 @@ We finish with the following result,
 the problem that started the branch of representation theory.
 Given a finite group $G$,
 we create $n$ variables $\{x_g\}_{g \in G}$,
-and an $n \times n$ matrix $M_G$ whose $(g,h)$th entry is $x_{gh}$.
+and an $n \times n$ matrix $M_G$ whose $(g,h)$th entry is $x_{gh^{-1}}$.
 \begin{example}[Frobenius determinants]
 	\listhack
 	\begin{enumerate}[(a)]


### PR DESCRIPTION
Fix some mistakes I discovered while reading.

1. Frobenius determinant: from online sources I have seen definitions of the Frobenius determinant using $x_{gh}$, $x_{gh^{-1}}$, or $x_{g^{-1}h}$. However, I believe the $x_{gh^{-1}}$ definition is needed to make the example (b) correct (it has a sign error now), and to make $T = \sum_{g \in G} x_g \rho(g)$ in the proof work.
2. Cauchy mean value theorem: this form of the theorem does not need $g(a) \neq g(b)$.
3. Power series of holomorphic functions: add the missing $\frac{1}{2\pi i}$ factors.
4. Problem 36B: I think the measurable sets would be just $\varnothing$ and $\Omega$, as for any other set $A$ we can pick $E$ with one point from $A$ and one point from $\Omega \setminus A$.
5. Lebesgue integration: move a precondition to the right place.
6. Example 38.1.4: I think $\mathbf{1}_{(k, \infty)}$ is the intended function.