### PR TITLE
fix typo

### DIFF
--- a/tex/riemann-surface/complex-structure.tex
+++ b/tex/riemann-surface/complex-structure.tex
@@ -5,7 +5,7 @@ Roughly speaking, the theory of Riemann surfaces is just the generalization of c
 using ideas from differential geometry:
 Just like how a $2$-manifold can be viewed as a collection of patches of the real plane $\RR^2$
 smoothly welded together to form a more complicated object,
-we take ``pieces'' of the complex plane $\CC$, \emph{analytically} welded together .
+we take ``pieces'' of the complex plane $\CC$, \emph{analytically} welded together.
 
 We already know that the theory of holomorphic function is very nice --- they're all analytic!
 The same amount of rigidity is to be expected here.


### PR DESCRIPTION
Fix typo in the description of Riemann surfaces.