### PR TITLE
fix: broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ you can consider [buying me a coffee](https://ko-fi.com/evanchen).
 
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=vEnhance/napkin&type=Date)](https://star-history.com/#vEnhance/napkin&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=vEnhance/napkin&type=Date)](https://star-history.dera.page/#vEnhance/napkin&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken, as the stargazer data source it depends on has been restricted and no longer serves the chart. This change points the chart at a working provider so the star history renders correctly again.