### PR TITLE
polish(linalg): mention prob:equal_dimension is used in Lagrange interpolation section

### DIFF
--- a/tex/linalg/vector-space.tex
+++ b/tex/linalg/vector-space.tex
@@ -1006,7 +1006,7 @@ says there is a unique line joining two points.
 	but $\deg P \le n$ and so $P$ can only be the zero polynomial.
 
 	So $T$ is an injective map between vector spaces of the same dimension.
-	Thus it is actually a bijection, which is exactly what we wanted.
+	Thus it is actually a bijection by \Cref{prob:equal_dimension}, which is exactly what we wanted.
 \end{proof}
 
 \section{Pedagogical digression: Arrays of numbers are evil}


### PR DESCRIPTION
Should be self-explanatory. Thanks a lot for this tremendous book !