### PR TITLE
fix: tiny typo in eigenvalues linalg chapter

### DIFF
--- a/tex/linalg/eigenvalues.tex
+++ b/tex/linalg/eigenvalues.tex
@@ -103,7 +103,7 @@ Of course, no mention to a basis anywhere.
 	\begin{enumerate}[(a)]
 		\ii Note that $e_1$ and $e_1 + e_2$ are
 		$2$-eigenvectors and $3$-eigenvectors.
-		\ii Of course, $5e_1$ is also an $2$-eigenvector.
+		\ii Of course, $5e_1$ is also a $2$-eigenvector.
 		\ii And, $7e_1 + 7e_2$ is also a $3$-eigenvector.
 	\end{enumerate}
 \end{example}


### PR DESCRIPTION
I think it should be "a" instead of "an" before $2$-eigenvector (like with $3$-eigenvector on the line below), though I'm not a native English speaker so I could be mistaken.
